### PR TITLE
Issue 3: update base vault images to point at quay.io/openbao/openbao; add more helm docs

### DIFF
--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.1.0
+version: 0.2.0
 appVersion: v2.0.0-alpha20240329
 kubeVersion: ">= 1.27.0-0"
 description: Official OpenBao Chart

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,8 +1,8 @@
 # openbao
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: v2.0.0-alpha20240329](https://img.shields.io/badge/AppVersion-v2.0.0--alpha20240329-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: v2.0.0-alpha20240329](https://img.shields.io/badge/AppVersion-v2.0.0--alpha20240329-informational?style=flat-square)
 
-Official openbao Chart
+Official OpenBao Chart
 
 **Homepage:** <https://github.com/openbao/openbao-helm>
 
@@ -10,7 +10,7 @@ Official openbao Chart
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| jessebot |  | <https://github.com/jessebot> |
+| OpenBao |  | <https://openbao.org> |
 
 ## Source Code
 
@@ -26,9 +26,10 @@ Kubernetes: `>= 1.27.0-0`
 |-----|------|---------|-------------|
 | csi.agent.enabled | bool | `true` |  |
 | csi.agent.extraArgs | list | `[]` |  |
-| csi.agent.image.pullPolicy | string | `"IfNotPresent"` |  |
-| csi.agent.image.repository | string | `"hashicorp/vault"` |  |
-| csi.agent.image.tag | string | `"1.15.2"` |  |
+| csi.agent.image.pullPolicy | string | `"IfNotPresent"` | image pull policy to use for agent image. if tag is "latest", set to "Always" |
+| csi.agent.image.registry | string | `"quay.io"` | image registry to use for agent image |
+| csi.agent.image.repository | string | `"openbao/openbao"` | image repo to use for agent image |
+| csi.agent.image.tag | string | `"2.0.0-alpha20240329"` | image tag to use for agent image |
 | csi.agent.logFormat | string | `"standard"` |  |
 | csi.agent.logLevel | string | `"info"` |  |
 | csi.agent.resources | object | `{}` |  |
@@ -41,12 +42,13 @@ Kubernetes: `>= 1.27.0-0`
 | csi.daemonSet.updateStrategy.maxUnavailable | string | `""` |  |
 | csi.daemonSet.updateStrategy.type | string | `"RollingUpdate"` |  |
 | csi.debug | bool | `false` |  |
-| csi.enabled | bool | `false` |  |
+| csi.enabled | bool | `false` | True if you want to install a secrets-store-csi-driver-provider-vault daemonset.  Requires installing the secrets-store-csi-driver separately, see: https://github.com/kubernetes-sigs/secrets-store-csi-driver#install-the-secrets-store-csi-driver  With the driver and provider installed, you can mount Vault secrets into volumes similar to the Vault Agent injector, and you can also sync those secrets into Kubernetes secrets. |
 | csi.extraArgs | list | `[]` |  |
 | csi.hmacSecretName | string | `""` |  |
-| csi.image.pullPolicy | string | `"IfNotPresent"` |  |
-| csi.image.repository | string | `"hashicorp/vault-csi-provider"` |  |
-| csi.image.tag | string | `"1.4.1"` |  |
+| csi.image.pullPolicy | string | `"IfNotPresent"` | image pull policy to use for csi image. if tag is "latest", set to "Always" |
+| csi.image.registry | string | `"docker.io"` | image registry to use for csi image |
+| csi.image.repository | string | `"hashicorp/vault-csi-provider"` | image repo to use for csi image |
+| csi.image.tag | string | `"1.4.1"` | image tag to use for csi image |
 | csi.livenessProbe.failureThreshold | int | `2` |  |
 | csi.livenessProbe.initialDelaySeconds | int | `5` |  |
 | csi.livenessProbe.periodSeconds | int | `5` |  |
@@ -66,17 +68,17 @@ Kubernetes: `>= 1.27.0-0`
 | csi.resources | object | `{}` |  |
 | csi.serviceAccount.annotations | object | `{}` |  |
 | csi.serviceAccount.extraLabels | object | `{}` |  |
-| csi.volumeMounts | string | `nil` |  |
-| csi.volumes | string | `nil` |  |
-| global.enabled | bool | `true` |  |
-| global.externalVaultAddr | string | `""` |  |
-| global.imagePullSecrets | list | `[]` |  |
-| global.namespace | string | `""` |  |
-| global.openshift | bool | `false` |  |
-| global.psp.annotations | string | `"seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default,runtime/default\napparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default\nseccomp.security.alpha.kubernetes.io/defaultProfileName:  runtime/default\napparmor.security.beta.kubernetes.io/defaultProfileName:  runtime/default\n"` |  |
-| global.psp.enable | bool | `false` |  |
-| global.serverTelemetry.prometheusOperator | bool | `false` |  |
-| global.tlsDisable | bool | `true` |  |
+| csi.volumeMounts | string | `nil` | volumeMounts is a list of volumeMounts for the main server container. These are rendered via toYaml rather than pre-processed like the extraVolumes value. The purpose is to make it easy to share volumes between containers. |
+| csi.volumes | string | `nil` | volumes is a list of volumes made available to all containers. These are rendered via toYaml rather than pre-processed like the extraVolumes value. The purpose is to make it easy to share volumes between containers. |
+| global.enabled | bool | `true` | enabled is the master enabled switch. Setting this to true or false will enable or disable all the components within this chart by default. |
+| global.externalVaultAddr | string | `""` | External vault server address for the injector and CSI provider to use. Setting this will disable deployment of a vault server. |
+| global.imagePullSecrets | list | `[]` | Image pull secret to use for registry authentication. Alternatively, the value may be specified as an array of strings. |
+| global.namespace | string | `""` | The namespace to deploy to. Defaults to the `helm` installation namespace. |
+| global.openshift | bool | `false` | If deploying to OpenShift |
+| global.psp | object | `{"annotations":"seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default,runtime/default\napparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default\nseccomp.security.alpha.kubernetes.io/defaultProfileName:  runtime/default\napparmor.security.beta.kubernetes.io/defaultProfileName:  runtime/default\n","enable":false}` | Create PodSecurityPolicy for pods |
+| global.psp.annotations | string | `"seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default,runtime/default\napparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default\nseccomp.security.alpha.kubernetes.io/defaultProfileName:  runtime/default\napparmor.security.beta.kubernetes.io/defaultProfileName:  runtime/default\n"` | Annotation for PodSecurityPolicy. This is a multi-line templated string map, and can also be set as YAML. |
+| global.serverTelemetry.prometheusOperator | bool | `false` | Enable integration with the Prometheus Operator See the top level serverTelemetry section below before enabling this feature. |
+| global.tlsDisable | bool | `true` | TLS for end-to-end encrypted transport |
 | injector.affinity | string | `"podAntiAffinity:\n  requiredDuringSchedulingIgnoredDuringExecution:\n    - labelSelector:\n        matchLabels:\n          app.kubernetes.io/name: {{ template \"vault.name\" . }}-agent-injector\n          app.kubernetes.io/instance: \"{{ .Release.Name }}\"\n          component: webhook\n      topologyKey: kubernetes.io/hostname\n"` |  |
 | injector.agentDefaults.cpuLimit | string | `"500m"` |  |
 | injector.agentDefaults.cpuRequest | string | `"250m"` |  |
@@ -85,43 +87,47 @@ Kubernetes: `>= 1.27.0-0`
 | injector.agentDefaults.template | string | `"map"` |  |
 | injector.agentDefaults.templateConfig.exitOnRetryFailure | bool | `true` |  |
 | injector.agentDefaults.templateConfig.staticSecretRenderInterval | string | `""` |  |
-| injector.agentImage.repository | string | `"hashicorp/vault"` |  |
-| injector.agentImage.tag | string | `"1.15.2"` |  |
+| injector.agentImage | object | `{"pullPolicy":"IfNotPresent","registry":"quay.io","repository":"openbao/openbao","tag":"2.0.0-alpha20240329"}` | agentImage sets the repo and tag of the Vault image to use for the Vault Agent containers.  This should be set to the official Vault image.  Vault 1.3.1+ is required. |
+| injector.agentImage.pullPolicy | string | `"IfNotPresent"` | image pull policy to use for agent image. if tag is "latest", set to "Always" |
+| injector.agentImage.registry | string | `"quay.io"` | image registry to use for agent image |
+| injector.agentImage.repository | string | `"openbao/openbao"` | image repo to use for agent image |
+| injector.agentImage.tag | string | `"2.0.0-alpha20240329"` | image tag to use for agent image |
 | injector.annotations | object | `{}` |  |
 | injector.authPath | string | `"auth/kubernetes"` |  |
 | injector.certs.caBundle | string | `""` |  |
 | injector.certs.certName | string | `"tls.crt"` |  |
 | injector.certs.keyName | string | `"tls.key"` |  |
 | injector.certs.secretName | string | `nil` |  |
-| injector.enabled | string | `"-"` |  |
-| injector.externalVaultAddr | string | `""` |  |
+| injector.enabled | string | `"-"` | True if you want to enable vault agent injection. @default: global.enabled |
+| injector.externalVaultAddr | string | `""` | Deprecated: Please use global.externalVaultAddr instead. |
 | injector.extraEnvironmentVars | object | `{}` |  |
 | injector.extraLabels | object | `{}` |  |
 | injector.failurePolicy | string | `"Ignore"` |  |
 | injector.hostNetwork | bool | `false` |  |
-| injector.image.pullPolicy | string | `"IfNotPresent"` |  |
-| injector.image.repository | string | `"hashicorp/vault-k8s"` |  |
-| injector.image.tag | string | `"1.3.1"` |  |
-| injector.leaderElector.enabled | bool | `true` |  |
-| injector.livenessProbe.failureThreshold | int | `2` |  |
-| injector.livenessProbe.initialDelaySeconds | int | `5` |  |
-| injector.livenessProbe.periodSeconds | int | `2` |  |
-| injector.livenessProbe.successThreshold | int | `1` |  |
-| injector.livenessProbe.timeoutSeconds | int | `5` |  |
-| injector.logFormat | string | `"standard"` |  |
-| injector.logLevel | string | `"info"` |  |
-| injector.metrics.enabled | bool | `false` |  |
+| injector.image.pullPolicy | string | `"IfNotPresent"` | image pull policy to use for k8s image. if tag is "latest", set to "Always" |
+| injector.image.registry | string | `"docker.io"` | image registry to use for k8s image |
+| injector.image.repository | string | `"hashicorp/vault-k8s"` | image repo to use for k8s image |
+| injector.image.tag | string | `"1.3.1"` | image tag to use for k8s image |
+| injector.leaderElector | object | `{"enabled":true}` | If multiple replicas are specified, by default a leader will be determined so that only one injector attempts to create TLS certificates. |
+| injector.livenessProbe.failureThreshold | int | `2` | When a probe fails, Kubernetes will try failureThreshold times before giving up |
+| injector.livenessProbe.initialDelaySeconds | int | `5` | Number of seconds after the container has started before probe initiates |
+| injector.livenessProbe.periodSeconds | int | `2` | How often (in seconds) to perform the probe |
+| injector.livenessProbe.successThreshold | int | `1` | Minimum consecutive successes for the probe to be considered successful after having failed |
+| injector.livenessProbe.timeoutSeconds | int | `5` | Number of seconds after which the probe times out. |
+| injector.logFormat | string | `"standard"` | Configures the log format of the injector. Supported log formats: "standard", "json". |
+| injector.logLevel | string | `"info"` | Configures the log verbosity of the injector. Supported log levels include: trace, debug, info, warn, error |
+| injector.metrics | object | `{"enabled":false}` | If true, will enable a node exporter metrics endpoint at /metrics. |
 | injector.namespaceSelector | object | `{}` |  |
 | injector.nodeSelector | object | `{}` |  |
 | injector.objectSelector | object | `{}` |  |
 | injector.podDisruptionBudget | object | `{}` |  |
-| injector.port | int | `8080` |  |
+| injector.port | int | `8080` | Configures the port the injector should listen on |
 | injector.priorityClassName | string | `""` |  |
-| injector.readinessProbe.failureThreshold | int | `2` |  |
-| injector.readinessProbe.initialDelaySeconds | int | `5` |  |
-| injector.readinessProbe.periodSeconds | int | `2` |  |
-| injector.readinessProbe.successThreshold | int | `1` |  |
-| injector.readinessProbe.timeoutSeconds | int | `5` |  |
+| injector.readinessProbe.failureThreshold | int | `2` | When a probe fails, Kubernetes will try failureThreshold times before giving up |
+| injector.readinessProbe.initialDelaySeconds | int | `5` | Number of seconds after the container has started before probe initiates |
+| injector.readinessProbe.periodSeconds | int | `2` | How often (in seconds) to perform the probe |
+| injector.readinessProbe.successThreshold | int | `1` | Minimum consecutive successes for the probe to be considered successful after having failed |
+| injector.readinessProbe.timeoutSeconds | int | `5` | Number of seconds after which the probe times out. |
 | injector.replicas | int | `1` |  |
 | injector.resources | object | `{}` |  |
 | injector.revokeOnShutdown | bool | `false` |  |
@@ -129,11 +135,11 @@ Kubernetes: `>= 1.27.0-0`
 | injector.securityContext.pod | object | `{}` |  |
 | injector.service.annotations | object | `{}` |  |
 | injector.serviceAccount.annotations | object | `{}` |  |
-| injector.startupProbe.failureThreshold | int | `12` |  |
-| injector.startupProbe.initialDelaySeconds | int | `5` |  |
-| injector.startupProbe.periodSeconds | int | `5` |  |
-| injector.startupProbe.successThreshold | int | `1` |  |
-| injector.startupProbe.timeoutSeconds | int | `5` |  |
+| injector.startupProbe.failureThreshold | int | `12` | When a probe fails, Kubernetes will try failureThreshold times before giving up |
+| injector.startupProbe.initialDelaySeconds | int | `5` | Number of seconds after the container has started before probe initiates |
+| injector.startupProbe.periodSeconds | int | `5` | How often (in seconds) to perform the probe |
+| injector.startupProbe.successThreshold | int | `1` | Minimum consecutive successes for the probe to be considered successful after having failed |
+| injector.startupProbe.timeoutSeconds | int | `5` | Number of seconds after which the probe times out. |
 | injector.strategy | object | `{}` |  |
 | injector.tolerations | list | `[]` |  |
 | injector.topologySpreadConstraints | list | `[]` |  |
@@ -187,9 +193,10 @@ Kubernetes: `>= 1.27.0-0`
 | server.ha.replicas | int | `3` |  |
 | server.hostAliases | list | `[]` |  |
 | server.hostNetwork | bool | `false` |  |
-| server.image.pullPolicy | string | `"IfNotPresent"` |  |
-| server.image.repository | string | `"hashicorp/vault"` |  |
-| server.image.tag | string | `"1.15.2"` |  |
+| server.image.pullPolicy | string | `"IfNotPresent"` | image pull policy to use for server image. if tag is "latest", set to "Always" |
+| server.image.registry | string | `"quay.io"` | image registry to use for server image |
+| server.image.repository | string | `"openbao/openbao"` | image repo to use for server image |
+| server.image.tag | string | `"2.0.0-alpha20240329"` | image tag to use for server image |
 | server.ingress.activeService | bool | `true` |  |
 | server.ingress.annotations | object | `{}` |  |
 | server.ingress.enabled | bool | `false` |  |

--- a/charts/openbao/templates/csi-daemonset.yaml
+++ b/charts/openbao/templates/csi-daemonset.yaml
@@ -51,7 +51,7 @@ spec:
         - name: {{ include "vault.name" . }}-csi-provider
           {{ template "csi.resources" . }}
           {{ template "csi.daemonSet.securityContext.container" . }}
-          image: "{{ .Values.csi.image.repository }}:{{ .Values.csi.image.tag }}"
+          image: "{{ .Values.csi.image.registry | default "docker.io" }}/{{ .Values.csi.image.repository }}:{{ .Values.csi.image.tag }}"
           imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
           args:
             - --endpoint=/provider/vault.sock

--- a/charts/openbao/templates/injector-deployment.yaml
+++ b/charts/openbao/templates/injector-deployment.yaml
@@ -50,7 +50,7 @@ spec:
       containers:
         - name: sidecar-injector
           {{ template "injector.resources" . }}
-          image: "{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
+          image: "{{ .Values.injector.image.registry | default "docker.io" }}/{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
           imagePullPolicy: "{{ .Values.injector.image.pullPolicy }}"
           {{- template "injector.securityContext.container" . }}
           env:

--- a/charts/openbao/templates/server-statefulset.yaml
+++ b/charts/openbao/templates/server-statefulset.yaml
@@ -75,7 +75,7 @@ spec:
       containers:
         - name: vault
           {{ template "vault.resources" . }}
-          image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
+          image: {{ .Values.server.image.registry | default "docker.io" }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command:
           - "/bin/sh"

--- a/charts/openbao/templates/tests/server-test.yaml
+++ b/charts/openbao/templates/tests/server-test.yaml
@@ -17,7 +17,7 @@ spec:
   {{- include "imagePullSecrets" . | nindent 2 }}
   containers:
     - name: {{ .Release.Name }}-server-test
-      image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
+      image: {{ .Values.server.image.registry | default "docker.io" }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
       imagePullPolicy: {{ .Values.server.image.pullPolicy }}
       env:
         - name: VAULT_ADDR

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -723,7 +723,7 @@ server:
 
     # Configures the service type for the main Vault service.  Can be ClusterIP
     # or NodePort.
-    #type: ClusterIP
+    # type: ClusterIP
 
     # The IP family and IP families options are to set the behaviour in a dual-stack environment.
     # Omitting these values will let the service fall back to whatever the CNI dictates the defaults
@@ -753,12 +753,12 @@ server:
 
     # If type is set to "NodePort", a specific nodePort value can be configured,
     # will be random if left blank.
-    #nodePort: 30000
+    # nodePort: 30000
 
     # When HA mode is enabled
     # If type is set to "NodePort", a specific nodePort value can be configured,
     # will be random if left blank.
-    #activeNodePort: 30001
+    # activeNodePort: 30001
 
     # When HA mode is enabled
     # If type is set to "NodePort", a specific nodePort value can be configured,
@@ -1076,7 +1076,7 @@ ui:
   # ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-traffic-policy
   externalTrafficPolicy: Cluster
 
-  #loadBalancerSourceRanges:
+  # loadBalancerSourceRanges:
   #   - 10.0.0.0/16
   #   - 1.78.23.3/32
 
@@ -1309,32 +1309,32 @@ serverTelemetry:
     scrapeTimeout: 10s
 
   prometheusRules:
-      # The Prometheus operator *must* be installed before enabling this feature,
-      # if not the chart will fail to install due to missing CustomResourceDefinitions
-      # provided by the operator.
+    # The Prometheus operator *must* be installed before enabling this feature,
+    # if not the chart will fail to install due to missing CustomResourceDefinitions
+    # provided by the operator.
 
-      # Deploy the PrometheusRule custom resource for AlertManager based alerts.
-      # Requires that AlertManager is properly deployed.
-      enabled: false
+    # Deploy the PrometheusRule custom resource for AlertManager based alerts.
+    # Requires that AlertManager is properly deployed.
+    enabled: false
 
-      # Selector labels to add to the PrometheusRules.
-      # When empty, defaults to:
-      #  release: prometheus
-      selectors: {}
+    # Selector labels to add to the PrometheusRules.
+    # When empty, defaults to:
+    #  release: prometheus
+    selectors: {}
 
-      # Some example rules.
-      rules: []
-      #  - alert: vault-HighResponseTime
-      #    annotations:
-      #      message: The response time of Vault is over 500ms on average over the last 5 minutes.
-      #    expr: vault_core_handle_request{quantile="0.5", namespace="mynamespace"} > 500
-      #    for: 5m
-      #    labels:
-      #      severity: warning
-      #  - alert: vault-HighResponseTime
-      #    annotations:
-      #      message: The response time of Vault is over 1s on average over the last 5 minutes.
-      #    expr: vault_core_handle_request{quantile="0.5", namespace="mynamespace"} > 1000
-      #    for: 5m
-      #    labels:
-      #      severity: critical
+    # Some example rules.
+    rules: []
+    #  - alert: vault-HighResponseTime
+    #    annotations:
+    #      message: The response time of Vault is over 500ms on average over the last 5 minutes.
+    #    expr: vault_core_handle_request{quantile="0.5", namespace="mynamespace"} > 500
+    #    for: 5m
+    #    labels:
+    #      severity: warning
+    #  - alert: vault-HighResponseTime
+    #    annotations:
+    #      message: The response time of Vault is over 1s on average over the last 5 minutes.
+    #    expr: vault_core_handle_request{quantile="0.5", namespace="mynamespace"} > 1000
+    #    for: 5m
+    #    labels:
+    #      severity: critical

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -763,7 +763,7 @@ server:
     # When HA mode is enabled
     # If type is set to "NodePort", a specific nodePort value can be configured,
     # will be random if left blank.
-    #standbyNodePort: 30002
+    # standbyNodePort: 30002
 
     # Port on which Vault server is listening
     port: 8200

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -4,33 +4,33 @@
 # Available parameters and their default values for the Vault chart.
 
 global:
-  # enabled is the master enabled switch. Setting this to true or false
+  # -- enabled is the master enabled switch. Setting this to true or false
   # will enable or disable all the components within this chart by default.
   enabled: true
 
-  # The namespace to deploy to. Defaults to the `helm` installation namespace.
+  # -- The namespace to deploy to. Defaults to the `helm` installation namespace.
   namespace: ""
 
-  # Image pull secret to use for registry authentication.
+  # -- Image pull secret to use for registry authentication.
   # Alternatively, the value may be specified as an array of strings.
   imagePullSecrets: []
   # imagePullSecrets:
   #   - name: image-pull-secret
 
-  # TLS for end-to-end encrypted transport
+  # -- TLS for end-to-end encrypted transport
   tlsDisable: true
 
-  # External vault server address for the injector and CSI provider to use.
+  # -- External vault server address for the injector and CSI provider to use.
   # Setting this will disable deployment of a vault server.
   externalVaultAddr: ""
 
-  # If deploying to OpenShift
+  # -- If deploying to OpenShift
   openshift: false
 
-  # Create PodSecurityPolicy for pods
+  # -- Create PodSecurityPolicy for pods
   psp:
     enable: false
-    # Annotation for PodSecurityPolicy.
+    # -- Annotation for PodSecurityPolicy.
     # This is a multi-line templated string map, and can also be set as YAML.
     annotations: |
       seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default,runtime/default
@@ -39,44 +39,54 @@ global:
       apparmor.security.beta.kubernetes.io/defaultProfileName:  runtime/default
 
   serverTelemetry:
-    # Enable integration with the Prometheus Operator
+    # -- Enable integration with the Prometheus Operator
     # See the top level serverTelemetry section below before enabling this feature.
     prometheusOperator: false
 
 injector:
-  # True if you want to enable vault agent injection.
-  # @default: global.enabled
+  # -- True if you want to enable vault agent injection. @default: global.enabled
   enabled: "-"
 
   replicas: 1
 
-  # Configures the port the injector should listen on
+  # -- Configures the port the injector should listen on
   port: 8080
 
-  # If multiple replicas are specified, by default a leader will be determined
+  # -- If multiple replicas are specified, by default a leader will be determined
   # so that only one injector attempts to create TLS certificates.
   leaderElector:
     enabled: true
 
-  # If true, will enable a node exporter metrics endpoint at /metrics.
+  # -- If true, will enable a node exporter metrics endpoint at /metrics.
   metrics:
     enabled: false
 
-  # Deprecated: Please use global.externalVaultAddr instead.
+  # -- Deprecated: Please use global.externalVaultAddr instead.
   externalVaultAddr: ""
 
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
+    # -- image registry to use for k8s image
+    registry: "docker.io"
+    # -- image repo to use for k8s image
     repository: "hashicorp/vault-k8s"
+    # -- image tag to use for k8s image
     tag: "1.3.1"
+    # -- image pull policy to use for k8s image. if tag is "latest", set to "Always"
     pullPolicy: IfNotPresent
 
-  # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
+  # -- agentImage sets the repo and tag of the Vault image to use for the Vault Agent
   # containers.  This should be set to the official Vault image.  Vault 1.3.1+ is
   # required.
   agentImage:
-    repository: "hashicorp/vault"
-    tag: "1.15.2"
+    # -- image registry to use for agent image
+    registry: "quay.io"
+    # -- image repo to use for agent image
+    repository: "openbao/openbao"
+    # -- image tag to use for agent image
+    tag: "2.0.0-alpha20240329"
+    # -- image pull policy to use for agent image. if tag is "latest", set to "Always"
+    pullPolicy: IfNotPresent
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -100,49 +110,49 @@ injector:
 
   # Used to define custom livenessProbe settings
   livenessProbe:
-    # When a probe fails, Kubernetes will try failureThreshold times before giving up
+    # -- When a probe fails, Kubernetes will try failureThreshold times before giving up
     failureThreshold: 2
-    # Number of seconds after the container has started before probe initiates
+    # -- Number of seconds after the container has started before probe initiates
     initialDelaySeconds: 5
-    # How often (in seconds) to perform the probe
+    # -- How often (in seconds) to perform the probe
     periodSeconds: 2
-    # Minimum consecutive successes for the probe to be considered successful after having failed
+    # -- Minimum consecutive successes for the probe to be considered successful after having failed
     successThreshold: 1
-    # Number of seconds after which the probe times out.
+    # -- Number of seconds after which the probe times out.
     timeoutSeconds: 5
   # Used to define custom readinessProbe settings
   readinessProbe:
-    # When a probe fails, Kubernetes will try failureThreshold times before giving up
+    # -- When a probe fails, Kubernetes will try failureThreshold times before giving up
     failureThreshold: 2
-    # Number of seconds after the container has started before probe initiates
+    # -- Number of seconds after the container has started before probe initiates
     initialDelaySeconds: 5
-    # How often (in seconds) to perform the probe
+    # -- How often (in seconds) to perform the probe
     periodSeconds: 2
-    # Minimum consecutive successes for the probe to be considered successful after having failed
+    # -- Minimum consecutive successes for the probe to be considered successful after having failed
     successThreshold: 1
-    # Number of seconds after which the probe times out.
+    # -- Number of seconds after which the probe times out.
     timeoutSeconds: 5
   # Used to define custom startupProbe settings
   startupProbe:
-    # When a probe fails, Kubernetes will try failureThreshold times before giving up
+    # -- When a probe fails, Kubernetes will try failureThreshold times before giving up
     failureThreshold: 12
-    # Number of seconds after the container has started before probe initiates
+    # -- Number of seconds after the container has started before probe initiates
     initialDelaySeconds: 5
-    # How often (in seconds) to perform the probe
+    # -- How often (in seconds) to perform the probe
     periodSeconds: 5
-    # Minimum consecutive successes for the probe to be considered successful after having failed
+    # -- Minimum consecutive successes for the probe to be considered successful after having failed
     successThreshold: 1
-    # Number of seconds after which the probe times out.
+    # -- Number of seconds after which the probe times out.
     timeoutSeconds: 5
 
   # Mount Path of the Vault Kubernetes Auth Method.
   authPath: "auth/kubernetes"
 
-  # Configures the log verbosity of the injector.
+  # -- Configures the log verbosity of the injector.
   # Supported log levels include: trace, debug, info, warn, error
   logLevel: "info"
 
-  # Configures the log format of the injector. Supported log formats: "standard", "json".
+  # -- Configures the log format of the injector. Supported log formats: "standard", "json".
   logFormat: "standard"
 
   # Configures all Vault Agent sidecars to revoke their token when shutting down
@@ -376,9 +386,13 @@ server:
   # By default no direct resource request is made.
 
   image:
-    repository: "hashicorp/vault"
-    tag: "1.15.2"
-    # Overrides the default Image Pull Policy
+    # -- image registry to use for server image
+    registry: "quay.io"
+    # -- image repo to use for server image
+    repository: "openbao/openbao"
+    # -- image tag to use for server image
+    tag: "2.0.0-alpha20240329"
+    # -- image pull policy to use for server image. if tag is "latest", set to "Always"
     pullPolicy: IfNotPresent
 
   # Configure the Update Strategy Type for the StatefulSet
@@ -1075,7 +1089,7 @@ ui:
 
 # secrets-store-csi-driver-provider-vault
 csi:
-  # True if you want to install a secrets-store-csi-driver-provider-vault daemonset.
+  # -- True if you want to install a secrets-store-csi-driver-provider-vault daemonset.
   #
   # Requires installing the secrets-store-csi-driver separately, see:
   # https://github.com/kubernetes-sigs/secrets-store-csi-driver#install-the-secrets-store-csi-driver
@@ -1086,11 +1100,16 @@ csi:
   enabled: false
 
   image:
+    # -- image registry to use for csi image
+    registry: "docker.io"
+    # -- image repo to use for csi image
     repository: "hashicorp/vault-csi-provider"
+    # -- image tag to use for csi image
     tag: "1.4.1"
+    # -- image pull policy to use for csi image. if tag is "latest", set to "Always"
     pullPolicy: IfNotPresent
 
-  # volumes is a list of volumes made available to all containers. These are rendered
+  # -- volumes is a list of volumes made available to all containers. These are rendered
   # via toYaml rather than pre-processed like the extraVolumes value.
   # The purpose is to make it easy to share volumes between containers.
   volumes: null
@@ -1098,7 +1117,7 @@ csi:
   #   secret:
   #     secretName: vault-tls
 
-  # volumeMounts is a list of volumeMounts for the main server container. These are rendered
+  # -- volumeMounts is a list of volumeMounts for the main server container. These are rendered
   # via toYaml rather than pre-processed like the extraVolumes value.
   # The purpose is to make it easy to share volumes between containers.
   volumeMounts: null
@@ -1171,8 +1190,13 @@ csi:
     extraArgs: []
 
     image:
-      repository: "hashicorp/vault"
-      tag: "1.15.2"
+      # -- image registry to use for agent image
+      registry: "quay.io"
+      # -- image repo to use for agent image
+      repository: "openbao/openbao"
+      # -- image tag to use for agent image
+      tag: "2.0.0-alpha20240329"
+      # -- image pull policy to use for agent image. if tag is "latest", set to "Always"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
# Changes

- updates references to `hashicorp/vault` to `openbao/openbao` (and sets their tags to the latest on quay.io)
- adds `image.registry` to several all the image maps so we can use `quay.io` for right now, and other users can use their own personal registries of choice
- changes more comments to start with `# -- ` so that [helm-docs](https://github.com/norwoodj/helm-docs) picks them up to generate the `README.md` parameters table (though not all of them, as we can do a differnet PR for a  *FULL* doc pass)
- fix a bunch of comments that didn't have spaces after the `#` so that the linter would calm down

# Caveats
This only partially addresses #3 because the following images do not have openbao equivalents yet:
- hashicorp/vault-csi-provider <-- needs it's official repo forked (use commit before [hashicorp/vault-csi-provider@9910eb3](https://github.com/hashicorp/vault-csi-provider/commit/9910eb310316bb9d0d56163dd6882d1e5618fd9e))
- hashicorp/vault-k8s <-- not sure if this is available, have to hunt it down 🤷 

I vote we still move this forward, albeit after #7 is merged so that we can verify the tests are working. We can always do another PR to tackle the final two images that are referenced from hashicorp.

EDIT: https://github.com/openbao/openbao-helm/pull/7#issuecomment-2118805406 explains alternative ways of merging both changes from #7 and this PR :)