### PR TITLE
Use the CSI agent image registry from configuration

### DIFF
--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.5.0
+version: 0.5.1
 appVersion: v2.0.1
 kubeVersion: ">= 1.27.0-0"
 description: Official OpenBao Chart

--- a/charts/openbao/templates/csi-daemonset.yaml
+++ b/charts/openbao/templates/csi-daemonset.yaml
@@ -103,7 +103,7 @@ spec:
             timeoutSeconds: {{ .Values.csi.readinessProbe.timeoutSeconds }}
         {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
         - name: {{ include "openbao.name" . }}-agent
-          image: "{{ .Values.csi.agent.image.repository }}:{{ .Values.csi.agent.image.tag }}"
+          image: "{{ .Values.csi.agent.image.registry | default "docker.io" }}/{{ .Values.csi.agent.image.repository }}:{{ .Values.csi.agent.image.tag }}"
           imagePullPolicy: {{ .Values.csi.agent.image.pullPolicy }}
           {{ template "csi.agent.resources" . }}
           command:

--- a/charts/openbao/templates/csi-daemonset.yaml
+++ b/charts/openbao/templates/csi-daemonset.yaml
@@ -117,9 +117,9 @@ spec:
           ports:
             - containerPort: 8200
           env:
-            - name: VAULT_LOG_LEVEL
+            - name: BAO_LOG_LEVEL
               value: "{{ .Values.csi.agent.logLevel }}"
-            - name: VAULT_LOG_FORMAT
+            - name: BAO_LOG_FORMAT
               value: "{{ .Values.csi.agent.logFormat }}"
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
This was causing the agent to fail to start on amd64 because the `docker.io/openbao/openbao` image seems to only support ARM.

I also updated the environment variables that get passed to the bao agent to use `BAO_` prefix.