### PR TITLE
Add the `.injector.agentImage.registry` to the image path

### DIFF
--- a/charts/openbao/templates/injector-deployment.yaml
+++ b/charts/openbao/templates/injector-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - name: AGENT_INJECT_VAULT_AUTH_PATH
               value: {{ .Values.injector.authPath }}
             - name: AGENT_INJECT_VAULT_IMAGE
-              value: "{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag }}"
+              value: "{{ .Values.injector.image.registry | default "quay.io" }}/{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag }}"
             {{- if .Values.injector.certs.secretName }}
             - name: AGENT_INJECT_TLS_CERT_FILE
               value: "/etc/webhook/certs/{{ .Values.injector.certs.certName }}"


### PR DESCRIPTION
This PR fixes <https://github.com/openbao/openbao-helm/issues/22> by adding the `agentImage` registry a it to the `AGENT_INJECT_VAULT_IMAGE` path. and setting the default to <quay.io>, as the openbao image is hosted there