### PR TITLE
add missing namespace to injector namespace

### DIFF
--- a/charts/openbao/templates/injector-network-policy.yaml
+++ b/charts/openbao/templates/injector-network-policy.yaml
@@ -10,6 +10,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "openbao.fullname" . }}-agent-injector
+  namespace: {{ include "openbao.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "openbao.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
The injector networkpolicy is missing it's namespace which causes it to be deployed to the default namespace