### PR TITLE
Remove mlock

### DIFF
--- a/charts/openbao/templates/_helpers.tpl
+++ b/charts/openbao/templates/_helpers.tpl
@@ -1075,7 +1075,6 @@ config file from values
   {{- if or (eq .mode "ha") (eq .mode "standalone") }}
   {{- $type := typeOf (index .Values.server .mode).config }}
   {{- if eq $type "string" }}
-    disable_mlock = true
   {{- if eq .mode "standalone" }}
     {{ tpl .Values.server.standalone.config . | nindent 4 | trim }}
   {{- else if and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "false") }}
@@ -1085,9 +1084,9 @@ config file from values
   {{ end }}
   {{- else }}
   {{- if and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true") }}
-{{ merge (dict "disable_mlock" true) (index .Values.server .mode).raft.config | toPrettyJson | indent 4 }}
+{{ (index .Values.server .mode).raft.config | toPrettyJson | indent 4 }}
   {{- else }}
-{{ merge (dict "disable_mlock" true) (index .Values.server .mode).config | toPrettyJson | indent 4 }}
+{{ (index .Values.server .mode).config | toPrettyJson | indent 4 }}
   {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
This PR fixes a warning in the bao server logs when deploying via helm.

`mlock` was proposed for removal in the [`mlock` removal RFC](https://openbao.org/docs/rfcs/mlock-removal/) and merged in [openbao/openbao#363](https://github.com/openbao/openbao/pull/363) which was [first released in v2.0.0](https://github.com/openbao/openbao/releases/tag/v2.0.0) 

The `disable_mlock` config option [is currently hardcoded](https://github.com/naphelps/openbao-helm/blob/7ad371f159140ec998f15c045fba6309a26aaf44/charts/openbao/templates/_helpers.tpl#L1089) into the helm chart.

This leads to a warning in the openbao server logs when deploying via the helm chart: `{"@level":"warn","@message":"unknown or unsupported field disable_mlock found in configuration at /tmp/storageconfig.hcl:2:1","@timestamp":"2024-12-30T15:50:01.935705Z"}`
