### PR TITLE
Fix agent image registry in injector deployment

### DIFF
--- a/charts/openbao/templates/injector-deployment.yaml
+++ b/charts/openbao/templates/injector-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - name: AGENT_INJECT_VAULT_AUTH_PATH
               value: {{ .Values.injector.authPath }}
             - name: AGENT_INJECT_VAULT_IMAGE
-              value: "{{ .Values.injector.image.registry | default "quay.io" }}/{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag }}"
+              value: "{{ .Values.injector.agentImage.registry | default "quay.io" }}/{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag }}"
             {{- if .Values.injector.certs.secretName }}
             - name: AGENT_INJECT_TLS_CERT_FILE
               value: "/etc/webhook/certs/{{ .Values.injector.certs.certName }}"


### PR DESCRIPTION
The value for AGENT_INJECT_VAULT_IMAGE in injector-deployment.yaml incorrectly points to injector image's registry instead of the agent image registry. This changes the registry to the correct agent image one, so the agent image variable points to the correct image.

Issue #31  