### PR TITLE
update includeConfigAnnotation to match README/values

### DIFF
--- a/charts/openbao/templates/_helpers.tpl
+++ b/charts/openbao/templates/_helpers.tpl
@@ -448,7 +448,7 @@ Sets extra pod annotations
 */}}
 {{- define "openbao.annotations" }}
       annotations:
-  {{- if .Values.server.includeConfigAnnotation }}
+  {{- if .Values.server.configAnnotation }}
         openbao.hashicorp.com/config-checksum: {{ include "openbao.config" . | sha256sum }}
   {{- end }}
   {{- if .Values.server.annotations }}

--- a/charts/openbao/templates/server-config-configmap.yaml
+++ b/charts/openbao/templates/server-config-configmap.yaml
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/name: {{ include "openbao.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- if .Values.server.includeConfigAnnotation }}
+{{- if .Values.server.configAnnotation }}
   annotations:
     vault.hashicorp.com/config-checksum: {{ include "openbao.config" . | sha256sum }}
 {{- end }}

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -153,7 +153,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-config-configmap.yaml \
-      --set 'server.includeConfigAnnotation=true' \
+      --set 'server.configAnnotation=true' \
       . | tee /dev/stderr |
       yq '.metadata.annotations["vault.hashicorp.com/config-checksum"] == null' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1636,7 +1636,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \
-      --set 'server.includeConfigAnnotation=true' \
+      --set 'server.configAnnotation=true' \
       . | tee /dev/stderr |
       yq '.spec.template.metadata.annotations["openbao.hashicorp.com/config-checksum"] == null' | tee /dev/stderr)
   [ "${actual}" = "false" ]


### PR DESCRIPTION
The value of server.includeConfigAnnotation is presented in the README.md and values.yaml as server.configAnnotation.

Update the server configmap, _helpers.tpl and unit tests to align with the documentation.

Issue #32 