### PR TITLE
ensure tests run on PRs from forks

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -1,5 +1,5 @@
 name: Acceptance Tests
-on: [push, workflow_dispatch]
+on: [push, workflow_dispatch, pull_request]
 jobs:
   kind:
     strategy:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,5 @@
 name: Tests
-on: [push, workflow_dispatch]
+on: [push, workflow_dispatch, pull_request]
 jobs:
   bats-unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
A push trigger does not execute on pushes to fork branches and is
therefore not visible in the PR.

Signed-off-by: Jan Martens <jan@martens.eu.org>