### PR TITLE
fix: Set KIND_K8S_VERSION to lowest supported version of chart (1.30)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LOCAL_ACCEPTANCE_TESTS?=false
 KIND_CLUSTER_NAME?=openbao-helm
 
 # kind k8s version
-KIND_K8S_VERSION?=v1.29.2
+KIND_K8S_VERSION?=v1.30.10
 
 # Generate json schema for chart values. See test/README.md for more details.
 values-schema:


### PR DESCRIPTION
Proposed fix for issue:

#44 