### PR TITLE
feat: Introduce externalBaoAddr to set the external openbao server address

### DIFF
--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.11.0
+version: 0.12.0
 appVersion: v2.2.0
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart

--- a/charts/openbao/templates/_helpers.tpl
+++ b/charts/openbao/templates/_helpers.tpl
@@ -140,12 +140,26 @@ Add a special case for replicas=1, where it should default to 0 as well.
 {{- end -}}
 
 {{/*
+Resolve the external OpenBao/Vault address by checking global and injector values in order of precedence:
+1. global.externalBaoAddr
+2. global.externalVaultAddr 
+*/}}
+
+{{- define "openbao.externalAddr" -}}
+  {{- if .Values.global.externalBaoAddr -}}
+    {{- .Values.global.externalBaoAddr -}}
+  {{- else -}}
+    {{- .Values.global.externalVaultAddr -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Set the variable 'mode' to the server mode requested by the user to simplify
 template logic.
 */}}
 {{- define "openbao.mode" -}}
   {{- template "openbao.serverEnabled" . -}}
-  {{- if or (.Values.injector.externalVaultAddr) (.Values.global.externalVaultAddr) -}}
+  {{- if or (.Values.injector.externalVaultAddr) (.Values.global.externalVaultAddr) (.Values.global.externalBaoAddr) -}}
     {{- $_ := set . "mode" "external" -}}
   {{- else if not .serverEnabled -}}
     {{- $_ := set . "mode" "external" -}}

--- a/charts/openbao/templates/csi-agent-configmap.yaml
+++ b/charts/openbao/templates/csi-agent-configmap.yaml
@@ -18,8 +18,8 @@ metadata:
 data:
   config.hcl: |
     vault {
-        {{- if .Values.global.externalVaultAddr }}
-        "address" = "{{ .Values.global.externalVaultAddr }}"
+        {{- if include "openbao.externalAddr" . }}
+        "address" = "{{ include "openbao.externalAddr" . }}"
         {{- else }}
         "address" = "{{ include "openbao.scheme" . }}://{{ template "openbao.fullname" . }}.{{ include "openbao.namespace" . }}.svc:{{ .Values.server.service.port }}"
         {{- end }}

--- a/charts/openbao/templates/csi-daemonset.yaml
+++ b/charts/openbao/templates/csi-daemonset.yaml
@@ -68,8 +68,8 @@ spec:
             - name: VAULT_ADDR
             {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
               value: "unix:///var/run/vault/agent.sock"
-            {{- else if .Values.global.externalVaultAddr }}
-              value: "{{ .Values.global.externalVaultAddr }}"
+            {{- else if include "openbao.externalAddr" . }}
+              value: "{{ include "openbao.externalAddr" . }}"
             {{- else }}
               value: {{ include "openbao.scheme" . }}://{{ template "openbao.fullname" . }}.{{ include "openbao.namespace" . }}.svc:{{ .Values.server.service.port }}
             {{- end }}

--- a/charts/openbao/templates/injector-deployment.yaml
+++ b/charts/openbao/templates/injector-deployment.yaml
@@ -59,8 +59,8 @@ spec:
             - name: AGENT_INJECT_LOG_LEVEL
               value: {{ .Values.injector.logLevel | default "info" }}
             - name: AGENT_INJECT_VAULT_ADDR
-            {{- if .Values.global.externalVaultAddr }}
-              value: "{{ .Values.global.externalVaultAddr }}"
+            {{- if include "openbao.externalAddr" . }}
+              value: "{{ include "openbao.externalAddr" . }}"
             {{- else if .Values.injector.externalVaultAddr }}
               value: "{{ .Values.injector.externalVaultAddr }}"
             {{- else }}

--- a/charts/openbao/values.schema.json
+++ b/charts/openbao/values.schema.json
@@ -234,6 +234,9 @@
                 "externalVaultAddr": {
                     "type": "string"
                 },
+                "externalBaoAddr": {
+                    "type": "string"
+                },
                 "imagePullSecrets": {
                     "type": "array"
                 },

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -22,8 +22,9 @@ global:
 
   # -- External openbao server address for the injector and CSI provider to use.
   # Setting this will disable deployment of a openbao server.
-  externalVaultAddr: "" # -- Deprecated: Please use global.externalBaoAddr instead.
   externalBaoAddr: "" 
+  # -- Deprecated: Please use global.externalBaoAddr instead.
+  externalVaultAddr: ""
 
   # -- If deploying to OpenShift
   openshift: false

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -22,7 +22,7 @@ global:
 
   # -- External openbao server address for the injector and CSI provider to use.
   # Setting this will disable deployment of a openbao server.
-  externalBaoAddr: "" 
+  externalBaoAddr: ""
   # -- Deprecated: Please use global.externalBaoAddr instead.
   externalVaultAddr: ""
 

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -22,7 +22,8 @@ global:
 
   # -- External openbao server address for the injector and CSI provider to use.
   # Setting this will disable deployment of a openbao server.
-  externalVaultAddr: ""
+  externalVaultAddr: "" # -- Deprecated: Please use global.externalBaoAddr instead.
+  externalBaoAddr: "" 
 
   # -- If deploying to OpenShift
   openshift: false
@@ -61,7 +62,7 @@ injector:
   metrics:
     enabled: false
 
-  # -- Deprecated: Please use global.externalVaultAddr instead.
+  # -- Deprecated: Please use global.externalBaoAddr instead.
   externalVaultAddr: ""
 
   # image sets the repo and tag of the vault-k8s image to use for the injector.

--- a/test/unit/csi-agent-configmap.bats
+++ b/test/unit/csi-agent-configmap.bats
@@ -62,3 +62,26 @@ load _helpers
       yq -r '.data["config.hcl"]' | tee /dev/stderr)
   echo "${actual}" | grep "http://openbao-outside"
 }
+
+@test "csi/Agent-ConfigMap: OpenBao addr correctly set for externalBaoAddr" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-agent-configmap.yaml \
+      --set "csi.enabled=true" \
+      --set 'global.externalBaoAddr=http://openbao-outside' \
+      . | tee /dev/stderr |
+      yq -r '.data["config.hcl"]' | tee /dev/stderr)
+  echo "${actual}" | grep "http://openbao-outside"
+}
+
+@test "csi/Agent-ConfigMap: OpenBao addr correctly set for externalBaoAddr, verify if externalBaoAddr takes precendece over externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-agent-configmap.yaml \
+      --set "csi.enabled=true" \
+      --set 'global.externalBaoAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://vault-outside' \
+      . | tee /dev/stderr |
+      yq -r '.data["config.hcl"]' | tee /dev/stderr)
+  echo "${actual}" | grep "http://openbao-outside"
+}


### PR DESCRIPTION
This PR introduces a new field to specify the external Openbao server address. This is in part to remove and/or deprecate Hashicorp/Vault references as discussed in #6. 

In order to maintain backwards compatibility we should keep the `externalVaultAddr`.

A small helper is created to set the external address based on the field being used (i.e. `externalBaoAddr` or `externalVaultAddr`, with the preference for the `externalBaoAddr` field.

A comment is added to the `values.yaml` that mentions the deprecation of `externalVaultAddr` and suggesting to use `externalBaoAddr`. 