### PR TITLE
feat(serviceMonitor): add scrapeClass

### DIFF
--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.10.1
+version: 0.11.0
 appVersion: v2.2.0
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![AppVersion: v2.2.0](https://img.shields.io/badge/AppVersion-v2.2.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![AppVersion: v2.2.0](https://img.shields.io/badge/AppVersion-v2.2.0-informational?style=flat-square)
 
 Official OpenBao Chart
 
@@ -279,6 +279,7 @@ Kubernetes: `>= 1.30.0-0`
 | serverTelemetry.serviceMonitor.authorization | object | `{}` |  |
 | serverTelemetry.serviceMonitor.enabled | bool | `false` |  |
 | serverTelemetry.serviceMonitor.interval | string | `"30s"` |  |
+| serverTelemetry.serviceMonitor.scrapeClass | string | `""` |  |
 | serverTelemetry.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
 | serverTelemetry.serviceMonitor.selectors | object | `{}` |  |
 | serverTelemetry.serviceMonitor.tlsConfig | object | `{}` |  |

--- a/charts/openbao/templates/prometheus-servicemonitor.yaml
+++ b/charts/openbao/templates/prometheus-servicemonitor.yaml
@@ -23,6 +23,9 @@ metadata:
     release: prometheus
     {{- end }}
 spec:
+  {{- if .Values.serverTelemetry.serviceMonitor.scrapeClass }}
+  scrapeClass: {{ .Values.serverTelemetry.serviceMonitor.scrapeClass }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "openbao.name" . }}

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1309,6 +1309,9 @@ serverTelemetry:
     # authorization used for scraping the Vault metrics API.
     authorization: {}
 
+    # scrapeClass to be used by the serviceMonitor
+    scrapeClass: ""
+
   prometheusRules:
     # The Prometheus operator *must* be installed before enabling this feature,
     # if not the chart will fail to install due to missing CustomResourceDefinitions

--- a/test/unit/prometheus-servicemonitor.bats
+++ b/test/unit/prometheus-servicemonitor.bats
@@ -167,3 +167,14 @@ load _helpers
   [ "$(echo "$output" | yq -r '.spec.endpoints[0].authorization.credentials.key')" = "secretkey" ]
   [ "$(echo "$output" | yq -r '.spec.endpoints[0].authorization.credentials.name')" = "secretname" ]
 }
+
+@test "prometheus/ServiceMonitor-server: scrapeClass set" {
+  cd `chart_dir`
+  local output=$( (helm template \
+    --show-only templates/prometheus-servicemonitor.yaml \
+    --set 'serverTelemetry.serviceMonitor.enabled=true' \
+    --set 'serverTelemetry.serviceMonitor.scrapeClass=foo' \
+    .) | tee /dev/stderr)
+
+  [ "$(echo "$output" | yq -r '.spec.scrapeClass')" = "foo" ]
+}


### PR DESCRIPTION
* Adds `scrapeClass` feature to the serviceMonitor to be able to utilize this to define authorization for accessing the metrics endpoint.