### PR TITLE
docs: Set the correct earliest tested kubernetes version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OpenBao Helm Chart
 
 > :warning: **Please note**: We take OpenBao's security and our users' trust very seriously. If
-you believe you have found a security issue in OpenBao Helm, _please responsibly disclose_
-by contacting us at [openbao-security@lists.lfedge.org](mailto:openbao-security@lists.lfedge.org).
+> you believe you have found a security issue in OpenBao Helm, _please responsibly disclose_
+> by contacting us at [openbao-security@lists.lfedge.org](mailto:openbao-security@lists.lfedge.org).
 
 This repository contains the OpenBao Helm chart for installing
 and configuring OpenBao on Kubernetes. This chart supports multiple use
@@ -16,10 +16,10 @@ this README. Please refer to the Kubernetes and Helm documentation.
 
 The versions required are:
 
-  * **Helm 3.12+** - Earliest verison tested
-  * **Kubernetes 1.29+** - This is the earliest version of Kubernetes tested.
-    It is possible that this chart works with earlier versions but it is
-    untested.
+- **Helm 3.12+** - Earliest verison tested
+- **Kubernetes 1.30+** - This is the earliest version of Kubernetes tested.
+  It is possible that this chart works with earlier versions but it is
+  untested.
 
 ## Usage
 

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.10.1
+version: 0.11.0
 appVersion: v2.2.0
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.11.0
+version: 0.12.0
 appVersion: v2.2.0
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![AppVersion: v2.2.0](https://img.shields.io/badge/AppVersion-v2.2.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![AppVersion: v2.2.0](https://img.shields.io/badge/AppVersion-v2.2.0-informational?style=flat-square)
 
 Official OpenBao Chart
 
@@ -279,6 +279,7 @@ Kubernetes: `>= 1.30.0-0`
 | serverTelemetry.serviceMonitor.authorization | object | `{}` |  |
 | serverTelemetry.serviceMonitor.enabled | bool | `false` |  |
 | serverTelemetry.serviceMonitor.interval | string | `"30s"` |  |
+| serverTelemetry.serviceMonitor.scrapeClass | string | `""` |  |
 | serverTelemetry.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
 | serverTelemetry.serviceMonitor.selectors | object | `{}` |  |
 | serverTelemetry.serviceMonitor.tlsConfig | object | `{}` |  |

--- a/charts/openbao/templates/_helpers.tpl
+++ b/charts/openbao/templates/_helpers.tpl
@@ -140,12 +140,26 @@ Add a special case for replicas=1, where it should default to 0 as well.
 {{- end -}}
 
 {{/*
+Resolve the external OpenBao/Vault address by checking global and injector values in order of precedence:
+1. global.externalBaoAddr
+2. global.externalVaultAddr 
+*/}}
+
+{{- define "openbao.externalAddr" -}}
+  {{- if .Values.global.externalBaoAddr -}}
+    {{- .Values.global.externalBaoAddr -}}
+  {{- else -}}
+    {{- .Values.global.externalVaultAddr -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Set the variable 'mode' to the server mode requested by the user to simplify
 template logic.
 */}}
 {{- define "openbao.mode" -}}
   {{- template "openbao.serverEnabled" . -}}
-  {{- if or (.Values.injector.externalVaultAddr) (.Values.global.externalVaultAddr) -}}
+  {{- if or (.Values.injector.externalVaultAddr) (.Values.global.externalVaultAddr) (.Values.global.externalBaoAddr) -}}
     {{- $_ := set . "mode" "external" -}}
   {{- else if not .serverEnabled -}}
     {{- $_ := set . "mode" "external" -}}

--- a/charts/openbao/templates/csi-agent-configmap.yaml
+++ b/charts/openbao/templates/csi-agent-configmap.yaml
@@ -18,8 +18,8 @@ metadata:
 data:
   config.hcl: |
     vault {
-        {{- if .Values.global.externalVaultAddr }}
-        "address" = "{{ .Values.global.externalVaultAddr }}"
+        {{- if include "openbao.externalAddr" . }}
+        "address" = "{{ include "openbao.externalAddr" . }}"
         {{- else }}
         "address" = "{{ include "openbao.scheme" . }}://{{ template "openbao.fullname" . }}.{{ include "openbao.namespace" . }}.svc:{{ .Values.server.service.port }}"
         {{- end }}

--- a/charts/openbao/templates/csi-daemonset.yaml
+++ b/charts/openbao/templates/csi-daemonset.yaml
@@ -68,8 +68,8 @@ spec:
             - name: VAULT_ADDR
             {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
               value: "unix:///var/run/vault/agent.sock"
-            {{- else if .Values.global.externalVaultAddr }}
-              value: "{{ .Values.global.externalVaultAddr }}"
+            {{- else if include "openbao.externalAddr" . }}
+              value: "{{ include "openbao.externalAddr" . }}"
             {{- else }}
               value: {{ include "openbao.scheme" . }}://{{ template "openbao.fullname" . }}.{{ include "openbao.namespace" . }}.svc:{{ .Values.server.service.port }}
             {{- end }}

--- a/charts/openbao/templates/injector-deployment.yaml
+++ b/charts/openbao/templates/injector-deployment.yaml
@@ -59,8 +59,8 @@ spec:
             - name: AGENT_INJECT_LOG_LEVEL
               value: {{ .Values.injector.logLevel | default "info" }}
             - name: AGENT_INJECT_VAULT_ADDR
-            {{- if .Values.global.externalVaultAddr }}
-              value: "{{ .Values.global.externalVaultAddr }}"
+            {{- if include "openbao.externalAddr" . }}
+              value: "{{ include "openbao.externalAddr" . }}"
             {{- else if .Values.injector.externalVaultAddr }}
               value: "{{ .Values.injector.externalVaultAddr }}"
             {{- else }}

--- a/charts/openbao/templates/prometheus-servicemonitor.yaml
+++ b/charts/openbao/templates/prometheus-servicemonitor.yaml
@@ -23,6 +23,9 @@ metadata:
     release: prometheus
     {{- end }}
 spec:
+  {{- if .Values.serverTelemetry.serviceMonitor.scrapeClass }}
+  scrapeClass: {{ .Values.serverTelemetry.serviceMonitor.scrapeClass }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "openbao.name" . }}

--- a/charts/openbao/values.schema.json
+++ b/charts/openbao/values.schema.json
@@ -234,6 +234,9 @@
                 "externalVaultAddr": {
                     "type": "string"
                 },
+                "externalBaoAddr": {
+                    "type": "string"
+                },
                 "imagePullSecrets": {
                     "type": "array"
                 },

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1309,6 +1309,9 @@ serverTelemetry:
     # authorization used for scraping the Vault metrics API.
     authorization: {}
 
+    # scrapeClass to be used by the serviceMonitor
+    scrapeClass: ""
+
   prometheusRules:
     # The Prometheus operator *must* be installed before enabling this feature,
     # if not the chart will fail to install due to missing CustomResourceDefinitions

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -22,6 +22,8 @@ global:
 
   # -- External openbao server address for the injector and CSI provider to use.
   # Setting this will disable deployment of a openbao server.
+  externalBaoAddr: ""
+  # -- Deprecated: Please use global.externalBaoAddr instead.
   externalVaultAddr: ""
 
   # -- If deploying to OpenShift
@@ -61,7 +63,7 @@ injector:
   metrics:
     enabled: false
 
-  # -- Deprecated: Please use global.externalVaultAddr instead.
+  # -- Deprecated: Please use global.externalBaoAddr instead.
   externalVaultAddr: ""
 
   # image sets the repo and tag of the vault-k8s image to use for the injector.

--- a/test/unit/csi-agent-configmap.bats
+++ b/test/unit/csi-agent-configmap.bats
@@ -62,3 +62,26 @@ load _helpers
       yq -r '.data["config.hcl"]' | tee /dev/stderr)
   echo "${actual}" | grep "http://openbao-outside"
 }
+
+@test "csi/Agent-ConfigMap: OpenBao addr correctly set for externalBaoAddr" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-agent-configmap.yaml \
+      --set "csi.enabled=true" \
+      --set 'global.externalBaoAddr=http://openbao-outside' \
+      . | tee /dev/stderr |
+      yq -r '.data["config.hcl"]' | tee /dev/stderr)
+  echo "${actual}" | grep "http://openbao-outside"
+}
+
+@test "csi/Agent-ConfigMap: OpenBao addr correctly set for externalBaoAddr, verify if externalBaoAddr takes precendece over externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-agent-configmap.yaml \
+      --set "csi.enabled=true" \
+      --set 'global.externalBaoAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://vault-outside' \
+      . | tee /dev/stderr |
+      yq -r '.data["config.hcl"]' | tee /dev/stderr)
+  echo "${actual}" | grep "http://openbao-outside"
+}

--- a/test/unit/prometheus-servicemonitor.bats
+++ b/test/unit/prometheus-servicemonitor.bats
@@ -167,3 +167,14 @@ load _helpers
   [ "$(echo "$output" | yq -r '.spec.endpoints[0].authorization.credentials.key')" = "secretkey" ]
   [ "$(echo "$output" | yq -r '.spec.endpoints[0].authorization.credentials.name')" = "secretname" ]
 }
+
+@test "prometheus/ServiceMonitor-server: scrapeClass set" {
+  cd `chart_dir`
+  local output=$( (helm template \
+    --show-only templates/prometheus-servicemonitor.yaml \
+    --set 'serverTelemetry.serviceMonitor.enabled=true' \
+    --set 'serverTelemetry.serviceMonitor.scrapeClass=foo' \
+    .) | tee /dev/stderr)
+
+  [ "$(echo "$output" | yq -r '.spec.scrapeClass')" = "foo" ]
+}


### PR DESCRIPTION
Noticed that the README mentions the earliest version being tested is `1.29+`. Updated it to match the correct earliest version being tested i.e. `1.30+`.