### PR TITLE
fix: support UBI image for OpenShift compatibility

### DIFF
--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.13.0
+version: 0.13.1
 appVersion: v2.2.2
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![AppVersion: v2.2.2](https://img.shields.io/badge/AppVersion-v2.2.2-informational?style=flat-square)
+![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![AppVersion: v2.2.2](https://img.shields.io/badge/AppVersion-v2.2.2-informational?style=flat-square)
 
 Official OpenBao Chart
 

--- a/charts/openbao/values.openshift.yaml
+++ b/charts/openbao/values.openshift.yaml
@@ -13,14 +13,18 @@ injector:
 
   agentImage:
     registry: "quay.io"
-    repository: "openbao/openbao"
-    tag: "v2.2.2-ubi"
+    repository: "openbao/openbao-ubi"
+    tag: "2.2.2"
+    # Use UBI-based OpenBao image for better OpenShift compatibility
+    # See: https://openbao.org/docs/install/#container-registries
 
 server:
   image:
     registry: "quay.io"
-    repository: "openbao/openbao"
-    tag: "v2.2.2-ubi"
+    repository: "openbao/openbao-ubi"
+    tag: "2.2.2"
+    # Use UBI-based OpenBao image for better OpenShift compatibility
+    # See: https://openbao.org/docs/install/#container-registries
 
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"


### PR DESCRIPTION
This PR fixes repository for UBI based images, becuase they are in a separate quay.io repository as it is mentioned in [OpenBao Container Registries Documentation](https://openbao.org/docs/install/#container-registries).