### PR TITLE
Push chart to GHCR as OCI artifact

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -12,6 +12,7 @@ jobs:
     environment: helm-release
     permissions:
       contents: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,3 +37,21 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_GENERATE_RELEASE_NOTES: true
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Helm chart to GHCR as OCI artifact
+        run: |
+          chart_registry="ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+          for pkg in .cr-release-packages/*.tgz; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+
+            helm push "${pkg}" "oci://${chart_registry}"
+          done

--- a/README.md
+++ b/README.md
@@ -31,4 +31,10 @@ helm repo add openbao https://openbao.github.io/openbao-helm
 helm install openbao openbao/openbao
 ```
 
+Alternatively you can use the OCI based helm chart as well:
+
+```
+helm install oci://ghcr.io/openbao/charts/openbao
+```
+
 Please see the many options supported in the [`values.yaml`](./charts/openbao/values.yaml) file. These are also fully documented directly in the [openbao README](./charts/openbao/README.md) along with more detailed installation instructions.

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.15.0
+version: 0.15.1
 appVersion: v2.2.2
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![AppVersion: v2.2.2](https://img.shields.io/badge/AppVersion-v2.2.2-informational?style=flat-square)
+![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![AppVersion: v2.2.2](https://img.shields.io/badge/AppVersion-v2.2.2-informational?style=flat-square)
 
 Official OpenBao Chart
 


### PR DESCRIPTION
Ensures the chart is available for OCI-based Helm installs. Heavily inspired by [external-secrets' pipeline](https://github.com/external-secrets/external-secrets/blob/main/.github/workflows/helm.yml) minus the signing.

---

See [my fork's actions](https://github.com/siegy22/openbao-helm/actions/runs/15862397138/job/44722405091) for an example [release](https://github.com/siegy22/openbao-helm/pkgs/container/openbao-helm%2Fopenbao).


Let me know your thoughts, I'd love to hear some feedback.