### PR TITLE
chore: point security mailing list in bug report template to new domain

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 
 **Please note**: We take OpenBao's security and our users' trust very seriously. If
 you believe you have found a security issue in OpenBao Helm, _please responsibly disclose_
-by contacting us at [openbao-security@lists.openssf.org](mailto:openbao-security@lists.lfedge.org).
+by contacting us at [openbao-security@lists.openssf.org](mailto:openbao-security@lists.openssf.org).
 
 -->
 


### PR DESCRIPTION
Small chore PR to point another outdated mailing list link to the new OpenSSF domain.

Related to https://github.com/openbao/openbao/issues/1413.