### PR TITLE
fix: Allow OpenShift to also use Ingress

### DIFF
--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.16.1
+version: 0.16.2
 appVersion: v2.3.1
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.16.1](https://img.shields.io/badge/Version-0.16.1-informational?style=flat-square) ![AppVersion: v2.3.1](https://img.shields.io/badge/AppVersion-v2.3.1-informational?style=flat-square)
+![Version: 0.16.2](https://img.shields.io/badge/Version-0.16.2-informational?style=flat-square) ![AppVersion: v2.3.1](https://img.shields.io/badge/AppVersion-v2.3.1-informational?style=flat-square)
 
 Official OpenBao Chart
 

--- a/charts/openbao/templates/server-ingress.yaml
+++ b/charts/openbao/templates/server-ingress.yaml
@@ -3,7 +3,6 @@ Copyright (c) HashiCorp, Inc.
 SPDX-License-Identifier: MPL-2.0
 */}}
 
-{{- if not .Values.global.openshift }}
 {{ template "openbao.mode" . }}
 {{- if ne .mode "external" }}
 {{- if .Values.server.ingress.enabled -}}
@@ -63,7 +62,6 @@ spec:
                   number: {{ $servicePort }}
         {{- end }}
   {{- end }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR allows to use Ingress for OpenShift instead of only using OpenShift routes. Since values server.ingress and server.route are disabled by default, even if global.openshift is enabled there shouldn't be any interferences.