### PR TITLE
feat(agent-injector): migrate to openbao-agent-injector

### DIFF
--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -69,9 +69,9 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     # -- image registry to use for k8s image
-    registry: "docker.io"
+    registry: "quay.io"
     # -- image repo to use for k8s image
-    repository: "hashicorp/vault-k8s"
+    repository: "openbao/openbao-k8s"
     # -- image tag to use for k8s image
     tag: "1.4.2"
     # -- image pull policy to use for k8s image. if tag is "latest", set to "Always"

--- a/test/acceptance/injector-leader-elector.bats
+++ b/test/acceptance/injector-leader-elector.bats
@@ -22,7 +22,7 @@ load _helpers
   tries=0
   until [ $tries -ge 60 ]
   do
-    owner=$(kubectl get configmaps vault-k8s-leader -o json | jq -r .metadata.ownerReferences\[0\].name)
+    owner=$(kubectl get configmaps openbao-k8s-leader -o json | jq -r .metadata.ownerReferences\[0\].name)
     leader=$(kubectl get pods $owner -o json | jq -r .metadata.name)
     [ -n "${leader}" ] && [ "${leader}" != "null" ] && break
     ((++tries))

--- a/test/acceptance/injector-test/job.yaml
+++ b/test/acceptance/injector-test/job.yaml
@@ -21,14 +21,14 @@ spec:
       labels:
         app: pgdump
       annotations:
-        vault.hashicorp.com/agent-inject: "true"
-        vault.hashicorp.com/agent-inject-secret-db-creds: "database/creds/db-backup"
-        vault.hashicorp.com/agent-inject-template-db-creds: |
+        openbao.org/agent-inject: "true"
+        openbao.org/agent-inject-secret-db-creds: "database/creds/db-backup"
+        openbao.org/agent-inject-template-db-creds: |
           {{- with secret "database/creds/db-backup" -}}
           postgresql://{{ .Data.username }}:{{ .Data.password }}@postgres.acceptance.svc.cluster.local:5432/mydb
           {{- end }}
-        vault.hashicorp.com/role: "db-backup"
-        vault.hashicorp.com/agent-pre-populate-only: "true"
+        openbao.org/role: "db-backup"
+        openbao.org/agent-pre-populate-only: "true"
     spec:
       serviceAccountName: pgdump
       containers:


### PR DESCRIPTION
After the first release of `openbao-k8s` we can migrate from `vault-agent-injector` to `openbao-agent-injector`.
The first release is planned to not introduce any breaking change.

Currently `openbao-k8s` is not released, but it's github actions use the acceptance tests from `openbao-helm`, why I created this branch already.