### PR TITLE
chore: update kind in gh action workflows to v0.29.0

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           config: test/kind/config.yaml
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
-          version: v0.22.0
+          version: v0.29.0
       - run: bats --tap --timing ./test/acceptance
 permissions:
   contents: read

--- a/.github/workflows/lint-chart.yml
+++ b/.github/workflows/lint-chart.yml
@@ -41,6 +41,7 @@ jobs:
         uses: helm/kind-action@v1.10.0
         with:
           node_image: kindest/node:v1.30.8
+          version: v0.29.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)


### PR DESCRIPTION
Noticed that actions either use no specific or an old version of kind.

This PR updates the actions to use the latest version (v0.29.0) of kind.