### PR TITLE
fix(envs): extraSecretEnvironmentVars first

### DIFF
--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.16.3
+version: 0.16.4
 appVersion: v2.3.2
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.16.2](https://img.shields.io/badge/Version-0.16.2-informational?style=flat-square) ![AppVersion: v2.3.2](https://img.shields.io/badge/AppVersion-v2.3.2-informational?style=flat-square)
+![Version: 0.16.4](https://img.shields.io/badge/Version-0.16.4-informational?style=flat-square) ![AppVersion: v2.3.2](https://img.shields.io/badge/AppVersion-v2.3.2-informational?style=flat-square)
 
 Official OpenBao Chart
 

--- a/charts/openbao/templates/server-statefulset.yaml
+++ b/charts/openbao/templates/server-statefulset.yaml
@@ -138,8 +138,8 @@ spec:
               value: "{{ .Values.server.logFormat }}"
             {{- end }}
             {{ template "openbao.envs" . }}
-            {{- include "openbao.extraEnvironmentVars" .Values.server | nindent 12 }}
             {{- include "openbao.extraSecretEnvironmentVars" .Values.server | nindent 12 }}
+            {{- include "openbao.extraEnvironmentVars" .Values.server | nindent 12 }}
           volumeMounts:
           {{ template "openbao.mounts" . }}
             - name: home


### PR DESCRIPTION
Fixes https://github.com/openbao/openbao-helm/issues/37

- include extraSecretEnvironmentVars first, allowing extraEnvironmentVars to reference them for variable substitution.

Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>
