### PR TITLE
chore: Update to version 2.4.0

### DIFF
--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: openbao
-version: 0.16.4
-appVersion: v2.3.2
+version: 0.17.0
+appVersion: v2.4.0
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart
 home: https://github.com/openbao/openbao-helm

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.16.4](https://img.shields.io/badge/Version-0.16.4-informational?style=flat-square) ![AppVersion: v2.3.2](https://img.shields.io/badge/AppVersion-v2.3.2-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![AppVersion: v2.4.0](https://img.shields.io/badge/AppVersion-v2.4.0-informational?style=flat-square)
 
 Official OpenBao Chart
 
@@ -29,7 +29,7 @@ Kubernetes: `>= 1.30.0-0`
 | csi.agent.image.pullPolicy | string | `"IfNotPresent"` | image pull policy to use for agent image. if tag is "latest", set to "Always" |
 | csi.agent.image.registry | string | `"quay.io"` | image registry to use for agent image |
 | csi.agent.image.repository | string | `"openbao/openbao"` | image repo to use for agent image |
-| csi.agent.image.tag | string | `"2.3.2"` | image tag to use for agent image |
+| csi.agent.image.tag | string | `""` | image tag to use for agent image |
 | csi.agent.logFormat | string | `"standard"` |  |
 | csi.agent.logLevel | string | `"info"` |  |
 | csi.agent.resources | object | `{}` |  |
@@ -88,11 +88,11 @@ Kubernetes: `>= 1.30.0-0`
 | injector.agentDefaults.template | string | `"map"` |  |
 | injector.agentDefaults.templateConfig.exitOnRetryFailure | bool | `true` |  |
 | injector.agentDefaults.templateConfig.staticSecretRenderInterval | string | `""` |  |
-| injector.agentImage | object | `{"pullPolicy":"IfNotPresent","registry":"quay.io","repository":"openbao/openbao","tag":"2.3.2"}` | agentImage sets the repo and tag of the OpenBao image to use for the OpenBao Agent containers.  This should be set to the official OpenBao image.  OpenBao 1.3.1+ is required. |
+| injector.agentImage | object | `{"pullPolicy":"IfNotPresent","registry":"quay.io","repository":"openbao/openbao","tag":""}` | agentImage sets the repo and tag of the OpenBao image to use for the OpenBao Agent containers.  This should be set to the official OpenBao image.  OpenBao 1.3.1+ is required. |
 | injector.agentImage.pullPolicy | string | `"IfNotPresent"` | image pull policy to use for agent image. if tag is "latest", set to "Always" |
 | injector.agentImage.registry | string | `"quay.io"` | image registry to use for agent image |
 | injector.agentImage.repository | string | `"openbao/openbao"` | image repo to use for agent image |
-| injector.agentImage.tag | string | `"2.3.2"` | image tag to use for agent image |
+| injector.agentImage.tag | string | `""` | image tag to use for agent image |
 | injector.annotations | object | `{}` |  |
 | injector.authPath | string | `"auth/kubernetes"` |  |
 | injector.certs.caBundle | string | `""` |  |
@@ -195,7 +195,7 @@ Kubernetes: `>= 1.30.0-0`
 | server.image.pullPolicy | string | `"IfNotPresent"` | image pull policy to use for server image. if tag is "latest", set to "Always" |
 | server.image.registry | string | `"quay.io"` | image registry to use for server image |
 | server.image.repository | string | `"openbao/openbao"` | image repo to use for server image |
-| server.image.tag | string | `"2.3.2"` | image tag to use for server image |
+| server.image.tag | string | `""` | image tag to use for server image |
 | server.ingress.activeService | bool | `true` |  |
 | server.ingress.annotations | object | `{}` |  |
 | server.ingress.enabled | bool | `false` |  |

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -29,7 +29,7 @@ Kubernetes: `>= 1.30.0-0`
 | csi.agent.image.pullPolicy | string | `"IfNotPresent"` | image pull policy to use for agent image. if tag is "latest", set to "Always" |
 | csi.agent.image.registry | string | `"quay.io"` | image registry to use for agent image |
 | csi.agent.image.repository | string | `"openbao/openbao"` | image repo to use for agent image |
-| csi.agent.image.tag | string | `""` | image tag to use for agent image |
+| csi.agent.image.tag | string | `""` | image tag to use for agent image - defaults to chart appVersion |
 | csi.agent.logFormat | string | `"standard"` |  |
 | csi.agent.logLevel | string | `"info"` |  |
 | csi.agent.resources | object | `{}` |  |
@@ -92,7 +92,7 @@ Kubernetes: `>= 1.30.0-0`
 | injector.agentImage.pullPolicy | string | `"IfNotPresent"` | image pull policy to use for agent image. if tag is "latest", set to "Always" |
 | injector.agentImage.registry | string | `"quay.io"` | image registry to use for agent image |
 | injector.agentImage.repository | string | `"openbao/openbao"` | image repo to use for agent image |
-| injector.agentImage.tag | string | `""` | image tag to use for agent image |
+| injector.agentImage.tag | string | `""` | image tag to use for agent image - defaults to chart appVersion |
 | injector.annotations | object | `{}` |  |
 | injector.authPath | string | `"auth/kubernetes"` |  |
 | injector.certs.caBundle | string | `""` |  |
@@ -195,7 +195,7 @@ Kubernetes: `>= 1.30.0-0`
 | server.image.pullPolicy | string | `"IfNotPresent"` | image pull policy to use for server image. if tag is "latest", set to "Always" |
 | server.image.registry | string | `"quay.io"` | image registry to use for server image |
 | server.image.repository | string | `"openbao/openbao"` | image repo to use for server image |
-| server.image.tag | string | `""` | image tag to use for server image |
+| server.image.tag | string | `""` | image tag to use for server image - defaults to chart appVersion |
 | server.ingress.activeService | bool | `true` |  |
 | server.ingress.annotations | object | `{}` |  |
 | server.ingress.enabled | bool | `false` |  |

--- a/charts/openbao/templates/csi-daemonset.yaml
+++ b/charts/openbao/templates/csi-daemonset.yaml
@@ -103,7 +103,7 @@ spec:
             timeoutSeconds: {{ .Values.csi.readinessProbe.timeoutSeconds }}
         {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
         - name: {{ include "openbao.name" . }}-agent
-          image: "{{ .Values.csi.agent.image.registry | default "docker.io" }}/{{ .Values.csi.agent.image.repository }}:{{ .Values.csi.agent.image.tag }}"
+          image: "{{ .Values.csi.agent.image.registry | default "docker.io" }}/{{ .Values.csi.agent.image.repository }}:{{ .Values.csi.agent.image.tag | default (trimPrefix "v" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.csi.agent.image.pullPolicy }}
           {{ template "csi.agent.resources" . }}
           command:

--- a/charts/openbao/templates/injector-deployment.yaml
+++ b/charts/openbao/templates/injector-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - name: AGENT_INJECT_VAULT_AUTH_PATH
               value: {{ .Values.injector.authPath }}
             - name: AGENT_INJECT_VAULT_IMAGE
-              value: "{{ .Values.injector.agentImage.registry | default "quay.io" }}/{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag }}"
+              value: "{{ .Values.injector.agentImage.registry | default "quay.io" }}/{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag | default (trimPrefix "v" .Chart.AppVersion) }}"
             {{- if .Values.injector.certs.secretName }}
             - name: AGENT_INJECT_TLS_CERT_FILE
               value: "/etc/webhook/certs/{{ .Values.injector.certs.certName }}"

--- a/charts/openbao/templates/server-statefulset.yaml
+++ b/charts/openbao/templates/server-statefulset.yaml
@@ -75,7 +75,7 @@ spec:
       containers:
         - name: openbao
           {{ template "openbao.resources" . }}
-          image: {{ .Values.server.image.registry | default "docker.io" }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
+          image: "{{ .Values.server.image.registry | default "docker.io" }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default (trimPrefix "v" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command:
           - "/bin/sh"

--- a/charts/openbao/templates/tests/server-test.yaml
+++ b/charts/openbao/templates/tests/server-test.yaml
@@ -17,7 +17,7 @@ spec:
   {{- include "imagePullSecrets" . | nindent 2 }}
   containers:
     - name: {{ .Release.Name }}-server-test
-      image: {{ .Values.server.image.registry | default "docker.io" }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
+      image: {{ .Values.server.image.registry | default "docker.io" }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default (trimPrefix "v" .Chart.AppVersion) }}
       imagePullPolicy: {{ .Values.server.image.pullPolicy }}
       env:
         - name: VAULT_ADDR

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -85,7 +85,7 @@ injector:
     registry: "quay.io"
     # -- image repo to use for agent image
     repository: "openbao/openbao"
-    # -- image tag to use for agent image
+    # -- image tag to use for agent image - defaults to chart appVersion
     tag: ""
     # -- image pull policy to use for agent image. if tag is "latest", set to "Always"
     pullPolicy: IfNotPresent
@@ -380,7 +380,7 @@ server:
     registry: "quay.io"
     # -- image repo to use for server image
     repository: "openbao/openbao"
-    # -- image tag to use for server image
+    # -- image tag to use for server image - defaults to chart appVersion
     tag: ""
     # -- image pull policy to use for server image. if tag is "latest", set to "Always"
     pullPolicy: IfNotPresent
@@ -1183,7 +1183,7 @@ csi:
       registry: "quay.io"
       # -- image repo to use for agent image
       repository: "openbao/openbao"
-      # -- image tag to use for agent image
+      # -- image tag to use for agent image - defaults to chart appVersion
       tag: ""
       # -- image pull policy to use for agent image. if tag is "latest", set to "Always"
       pullPolicy: IfNotPresent

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -86,7 +86,7 @@ injector:
     # -- image repo to use for agent image
     repository: "openbao/openbao"
     # -- image tag to use for agent image
-    tag: "2.3.2"
+    tag: ""
     # -- image pull policy to use for agent image. if tag is "latest", set to "Always"
     pullPolicy: IfNotPresent
 
@@ -381,7 +381,7 @@ server:
     # -- image repo to use for server image
     repository: "openbao/openbao"
     # -- image tag to use for server image
-    tag: "2.3.2"
+    tag: ""
     # -- image pull policy to use for server image. if tag is "latest", set to "Always"
     pullPolicy: IfNotPresent
 
@@ -1184,7 +1184,7 @@ csi:
       # -- image repo to use for agent image
       repository: "openbao/openbao"
       # -- image tag to use for agent image
-      tag: "2.3.2"
+      tag: ""
       # -- image pull policy to use for agent image. if tag is "latest", set to "Always"
       pullPolicy: IfNotPresent
 

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -46,9 +46,10 @@ load _helpers
   [ "${actual}" = "quay.io/foo:1.2.3" ]
 }
 
-@test "server/ha-StatefulSet: image tag defaults to latest" {
+@test "server/ha-StatefulSet: image tag defaults to appVersion" {
   cd `chart_dir`
 
+  local appVersion=$(helm show chart . | yq -r '.appVersion' | tr -d "v")
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.image.repository=foo' \
@@ -56,7 +57,7 @@ load _helpers
       --set 'server.dev.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "quay.io/foo:latest" ]
+  [ "${actual}" = "quay.io/foo:${appVersion}" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -46,9 +46,10 @@ load _helpers
   [ "${actual}" = "quay.io/foo:1.2.3" ]
 }
 
-@test "server/ha-StatefulSet: image tag defaults to latest" {
+@test "server/ha-StatefulSet: image tag defaults to appVersion" {
   cd `chart_dir`
 
+  local appVersion=$(helm show chart . | yq -r '.appVersion' | tr -d "v")
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.image.repository=foo' \
@@ -56,7 +57,7 @@ load _helpers
       --set 'server.ha.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "quay.io/foo:latest" ]
+  [ "${actual}" = "quay.io/foo:${appVersion}" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -117,15 +117,16 @@ load _helpers
   [ "${actual}" = "quay.io/foo:1.2.3" ]
 }
 
-@test "server/standalone-StatefulSet: image tag defaults to latest" {
+@test "server/standalone-StatefulSet: image tag defaults to appVersion" {
   cd `chart_dir`
+  local appVersion=$(helm show chart . | yq -r '.appVersion' | tr -d "v")
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.image.repository=foo' \
       --set 'server.image.tag=' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "quay.io/foo:latest" ]
+  [ "${actual}" = "quay.io/foo:${appVersion}" ]
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
@@ -134,7 +135,7 @@ load _helpers
       --set 'server.standalone.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "quay.io/foo:latest" ]
+  [ "${actual}" = "quay.io/foo:${appVersion}" ]
 }
 
 @test "server/standalone-StatefulSet: default imagePullPolicy" {

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -146,15 +146,16 @@ load _helpers
   [ "${actual}" = "quay.io/foo:1.2.3" ]
 }
 
-@test "server/standalone-server-test-Pod: image tag defaults to latest" {
+@test "server/standalone-server-test-Pod: image tag defaults to appVersion" {
   cd `chart_dir`
+  local appVersion=$(helm show chart . | yq -r '.appVersion' | tr -d "v")
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml  \
       --set 'server.image.repository=foo' \
       --set 'server.image.tag=' \
       . | tee /dev/stderr |
       yq -r '.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "quay.io/foo:latest" ]
+  [ "${actual}" = "quay.io/foo:${appVersion}" ]
 
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml  \
@@ -163,7 +164,7 @@ load _helpers
       --set 'server.standalone.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "quay.io/foo:latest" ]
+  [ "${actual}" = "quay.io/foo:${appVersion}" ]
 }
 
 @test "server/standalone-server-test-Pod: default imagePullPolicy" {


### PR DESCRIPTION
- Updates to AppVersion 2.4.0
- Defaults to AppVersion from Chart.yaml when defining images instead of having to set it in values.yaml on several parts
- updates bats test for check appVersion and not `latest`