### PR TITLE
fix(csi): set provider path to openbao

### DIFF
--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.17.0
+version: 0.17.1
 appVersion: v2.4.0
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![AppVersion: v2.4.0](https://img.shields.io/badge/AppVersion-v2.4.0-informational?style=flat-square)
+![Version: 0.17.1](https://img.shields.io/badge/Version-0.17.1-informational?style=flat-square) ![AppVersion: v2.4.0](https://img.shields.io/badge/AppVersion-v2.4.0-informational?style=flat-square)
 
 Official OpenBao Chart
 
@@ -34,6 +34,7 @@ Kubernetes: `>= 1.30.0-0`
 | csi.agent.logLevel | string | `"info"` |  |
 | csi.agent.resources | object | `{}` |  |
 | csi.daemonSet.annotations | object | `{}` |  |
+| csi.daemonSet.endpoint | string | `"/provider/openbao.sock"` |  |
 | csi.daemonSet.extraLabels | object | `{}` |  |
 | csi.daemonSet.kubeletRootDir | string | `"/var/lib/kubelet"` |  |
 | csi.daemonSet.providersDir | string | `"/etc/kubernetes/secrets-store-csi-providers"` |  |

--- a/charts/openbao/templates/csi-daemonset.yaml
+++ b/charts/openbao/templates/csi-daemonset.yaml
@@ -54,7 +54,7 @@ spec:
           image: "{{ .Values.csi.image.registry | default "docker.io" }}/{{ .Values.csi.image.repository }}:{{ .Values.csi.image.tag }}"
           imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
           args:
-            - --endpoint={{ .Values.csi.endpoint }}
+            - --endpoint={{ .Values.csi.daemonSet.endpoint }}
             - --debug={{ .Values.csi.debug }}
             {{- if .Values.csi.hmacSecretName }}
             - --hmac-secret-name={{ .Values.csi.hmacSecretName }}

--- a/charts/openbao/templates/csi-daemonset.yaml
+++ b/charts/openbao/templates/csi-daemonset.yaml
@@ -54,7 +54,7 @@ spec:
           image: "{{ .Values.csi.image.registry | default "docker.io" }}/{{ .Values.csi.image.repository }}:{{ .Values.csi.image.tag }}"
           imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
           args:
-            - --endpoint=/provider/vault.sock
+            - --endpoint={{ .Values.csi.endpoint }}
             - --debug={{ .Values.csi.debug }}
             {{- if .Values.csi.hmacSecretName }}
             - --hmac-secret-name={{ .Values.csi.hmacSecretName }}

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1140,6 +1140,9 @@ csi:
     providersDir: "/etc/kubernetes/secrets-store-csi-providers"
     # Kubelet host path
     kubeletRootDir: "/var/lib/kubelet"
+    # endpoint path for the provider
+    endpoint: "/provider/openbao.sock"
+
     # Extra labels to attach to the vault-csi-provider daemonSet
     # This should be a YAML map of the labels to apply to the csi provider daemonSet
     extraLabels: {}

--- a/test/acceptance/csi-test/openbao-kv-secretproviderclass.yaml
+++ b/test/acceptance/csi-test/openbao-kv-secretproviderclass.yaml
@@ -7,7 +7,7 @@ kind: SecretProviderClass
 metadata:
   name: vault-kv
 spec:
-  provider: vault
+  provider: openbao
   parameters:
     roleName: "kv-role"
     objects: |

--- a/test/acceptance/csi.bats
+++ b/test/acceptance/csi.bats
@@ -11,7 +11,7 @@ load _helpers
   # Install Secrets Store CSI driver
   # Configure it to pass in a JWT for the provider to use, and rotate secrets rapidly
   # so we can see Agent's cache working.
-  CSI_DRIVER_VERSION=1.3.2
+  CSI_DRIVER_VERSION=1.5.3
   helm install secrets-store-csi-driver secrets-store-csi-driver \
     --repo https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts \
     --version=$CSI_DRIVER_VERSION \


### PR DESCRIPTION
Interestingly, I just experimented with setting `/provider/openbao.sock` as the path for the daemonset's endpoint, and as a result, the provider is now recognized as `openbao` instead of `vault`, allowing the CSI to work with the new `openbao` provider.

 I had to make the change here before updating it in `openbao-csi-provider` since it was hardcoded in the templates. After merging, I can proceed with updating everything (including tests) on the CSI side.

Related: https://github.com/openbao/openbao-csi-provider/pull/54