### PR TITLE
chore(openbao-csi): bump to version 2.0.0

### DIFF
--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.17.1
+version: 0.18.0
 appVersion: v2.4.0
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.17.1](https://img.shields.io/badge/Version-0.17.1-informational?style=flat-square) ![AppVersion: v2.4.0](https://img.shields.io/badge/AppVersion-v2.4.0-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![AppVersion: v2.4.0](https://img.shields.io/badge/AppVersion-v2.4.0-informational?style=flat-square)
 
 Official OpenBao Chart
 
@@ -49,7 +49,7 @@ Kubernetes: `>= 1.30.0-0`
 | csi.image.pullPolicy | string | `"IfNotPresent"` | image pull policy to use for csi image. if tag is "latest", set to "Always" |
 | csi.image.registry | string | `"quay.io"` | image registry to use for csi image |
 | csi.image.repository | string | `"openbao/openbao-csi-provider"` | image repo to use for csi image |
-| csi.image.tag | string | `"1.5.0"` | image tag to use for csi image |
+| csi.image.tag | string | `"2.0.0"` | image tag to use for csi image |
 | csi.livenessProbe.failureThreshold | int | `2` |  |
 | csi.livenessProbe.initialDelaySeconds | int | `5` |  |
 | csi.livenessProbe.periodSeconds | int | `5` |  |

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1094,7 +1094,7 @@ csi:
     # -- image repo to use for csi image
     repository: "openbao/openbao-csi-provider"
     # -- image tag to use for csi image
-    tag: "1.5.0"
+    tag: "2.0.0"
     # -- image pull policy to use for csi image. if tag is "latest", set to "Always"
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Bumps openbao-csi-provider to use version 2.0.0
Now working with `provider: openbao`
