### PR TITLE
fix(workflow/release): add `workflow_dispatch` to allow triggering manual releases

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Last PR didn't trigger a release as automatic releases are scoped to the folder `charts/**`, in order to trigger a release manually we need the action event `workflow_dispatch`.