### PR TITLE
give ocm job package write permissions

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -56,8 +56,10 @@ jobs:
 
             helm push "${pkg}" "oci://${chart_registry}"
           done
-          
+
   ocm:
+    permissions:
+      packages: write
     needs:
       - release
     name: Release OCM Artifact


### PR DESCRIPTION
See Action run here: https://github.com/openbao/openbao-helm/actions/runs/17674767979

Seems like we need to give the job more permissions, so the triggered workflow can have them.

I'm not 100% sure if this is enough, or of the whole parent workflow needs the `package: write` permissions.

Edit: tested in fork, it works