### PR TITLE
feat(artifacthub): add myself to owners file

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,15 @@
+# Artifact Hub repository metadata file
+#
+# Some settings like the verified publisher flag or the ignored packages won't
+# be applied until the next time the repository is processed. Please keep in
+# mind that the repository won't be processed if it has not changed since the
+# last time it was processed. Depending on the repository kind, this is checked
+# in a different way. For Helm http based repositories, we consider it has
+# changed if the `index.yaml` file changes. For git based repositories, it does
+# when the hash of the last commit in the branch you set up changes. This does
+# NOT apply to ownership claim operations, which are processed immediately.
+#
+# repositoryID: The ID of the Artifact Hub repository where the packages will be published to (optional, but it enables verified publisher)
+owners:
+  - name: pree
+    email: pascal@reeb.io


### PR DESCRIPTION
This sets myself as an owner of this repo which allows me to claim ownership on ArtifactHub.
I will be moving this to the "OpenBao" Organization inside ArtifactHub.

Once submitted we could remove the `owners` section again, alternatively we can add us all to the owners section.
Maybe an alternative would also be to create an OpenBao service account and add that to the owners.
`repositoryID` can also only be added once ownership was claimed.