### PR TITLE
fix(snapshotAgent): add resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.22.1
+
+- fix: add snapshotAgent resources to the templating, fixing #121
+
 ## 0.22.0
 
 - feat: added [openbao-snapshot-agent](https://github.com/openbao/openbao-snapshot-agent) as cronjob to chart

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.22.0
+version: 0.22.1
 appVersion: v2.4.4
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart
@@ -26,9 +26,9 @@ annotations:
   charts.openshift.io/name: Openbao
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: feature
+    - kind: fix
       description: |
-        feat: added snapshot-agent cronjob to chart
+        fix: added snapshot-agent cronjob resources to the chart
 
 maintainers:
   - name: OpenBao

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![AppVersion: v2.4.4](https://img.shields.io/badge/AppVersion-v2.4.4-informational?style=flat-square)
+![Version: 0.22.1](https://img.shields.io/badge/Version-0.22.1-informational?style=flat-square) ![AppVersion: v2.4.4](https://img.shields.io/badge/AppVersion-v2.4.4-informational?style=flat-square)
 
 Official OpenBao Chart
 
@@ -309,7 +309,8 @@ Kubernetes: `>= 1.30.0-0`
 | snapshotAgent.enabled | bool | `false` |  |
 | snapshotAgent.extraVolumes | object | `{}` |  |
 | snapshotAgent.image.repository | string | `"ghcr.io/openbao/openbao-snapshot-agent"` |  |
-| snapshotAgent.image.tag | string | `"0.2.3"` |  |
+| snapshotAgent.image.tag | string | `"0.2.4"` |  |
+| snapshotAgent.resources | object | `{}` |  |
 | snapshotAgent.restartPolicy | string | `"OnFailure"` |  |
 | snapshotAgent.s3CredentialsSecret | string | `"my-s3-credentials"` |  |
 | snapshotAgent.schedule | string | `"*/15 * * * *"` |  |

--- a/charts/openbao/templates/_helpers.tpl
+++ b/charts/openbao/templates/_helpers.tpl
@@ -880,7 +880,7 @@ Sets the container resources for CSI's Agent sidecar if the user has set any.
 {{- end -}}
 
 {{/*
-Set's the container resources for the SnapshotAGent if the user has set any.
+Set's the container resources for the SnapshotAgent if the user has set any.
 */}}
 {{- define "openbao.snapshotAgent.resources" -}}
   {{- if .Values.snapshotAgent.resources -}}

--- a/charts/openbao/templates/_helpers.tpl
+++ b/charts/openbao/templates/_helpers.tpl
@@ -880,6 +880,16 @@ Sets the container resources for CSI's Agent sidecar if the user has set any.
 {{- end -}}
 
 {{/*
+Set's the container resources for the SnapshotAGent if the user has set any.
+*/}}
+{{- define "openbao.snapshotAgent.resources" -}}
+  {{- if .Values.snapshotAgent.resources -}}
+          resources:
+{{ toYaml .Values.snapshotAgent.resources | indent 14}}
+  {{ end }}
+{{- end -}}
+
+{{/*
 Sets extra CSI daemonset annotations
 */}}
 {{- define "csi.daemonSet.annotations" -}}

--- a/charts/openbao/templates/snapshotagent-cronjob.yaml
+++ b/charts/openbao/templates/snapshotagent-cronjob.yaml
@@ -46,6 +46,7 @@ spec:
                   key: AWS_ACCESS_KEY_ID
                   name: {{ .Values.snapshotAgent.s3CredentialsSecret }}
             image: {{ .Values.snapshotAgent.image.repository }}:{{ .Values.snapshotAgent.image.tag }}
+            {{ template "openbao.snapshotAgent.resources". }}
             volumeMounts:
               - name: snapshot-dir
                 mountPath: /bao-snapshots

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1445,3 +1445,6 @@ snapshotAgent:
     s3cmdExtraFlag: "-v"
     baoAuthPath: "kubernetes"
     baoRole: "snapshot"
+
+  # configuration of the CronJobs resources
+  resources: {}

--- a/test/unit/snapshotagent.bats
+++ b/test/unit/snapshotagent.bats
@@ -3,7 +3,7 @@
 load _helpers
 
 @test "snapshotagent/cronjob: disabled by default" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local
   local actual=$( (helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
@@ -13,7 +13,7 @@ load _helpers
 }
 
 @test "snapshotagent/cronjob: namespace:" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -32,7 +32,7 @@ load _helpers
 }
 
 @test "snapshotagent/cronjob: annotations:" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -44,7 +44,7 @@ load _helpers
 }
 
 @test "snapshotagent/cronjob: schedule:" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -57,7 +57,7 @@ load _helpers
 }
 
 @test "snapshot/cronjob: extraVolumes" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -70,7 +70,7 @@ load _helpers
 }
 
 @test "snapshot/cronjob: image overwrite" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -82,8 +82,23 @@ load _helpers
   [ "${actual}" = "my-repo:my-tag" ]
 }
 
+@test "snapshot/cronjob: resources" {
+  cd $(chart_dir)
+  local actual=$(helm template \
+    --show-only templates/snapshotagent-cronjob.yaml \
+    --set 'snapshotAgent.enabled=true' \
+    --set 'snapshotAgent.resources.requests.cpu=100m' \
+    --set 'snapshotAgent.resources.requests.memory=100Mi' \
+    --set 'snapshotAgent.resources.limits.cpu=1000m' \
+    --set 'snapshotAgent.resources.limits.memory=1Gi' \
+    --namespace foo \
+    . | tee /dev/stderr |
+    yq -r '.spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu' | tee /dev/stderr)
+  [ "${actual}" = "100m" ]
+}
+
 @test "snapshot/cronjob: configuration: s3CredentialsSecret" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -103,7 +118,7 @@ load _helpers
 }
 
 @test "snapshot/serviceaccount: disabled" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -115,7 +130,7 @@ load _helpers
 }
 
 @test "snapshot/serviceaccount: own name" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -128,7 +143,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: s3Host" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -140,7 +155,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: s3Bucket" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -152,7 +167,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: s3Uri" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -164,7 +179,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: s3ExpireDays" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -176,7 +191,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: s3cmdExtraFlag" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -188,7 +203,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: baoAuthPath" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -200,7 +215,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: baoRole" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(
     helm template \
       --show-only templates/snapshotagent-configmap.yaml \
@@ -214,7 +229,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: baoAddr" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -225,7 +240,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: externalBaoAddr" {
-  cd `chart_dir`
+  cd $(chart_dir)
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \

--- a/test/unit/snapshotagent.bats
+++ b/test/unit/snapshotagent.bats
@@ -3,7 +3,7 @@
 load _helpers
 
 @test "snapshotagent/cronjob: disabled by default" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local
   local actual=$( (helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
@@ -13,7 +13,7 @@ load _helpers
 }
 
 @test "snapshotagent/cronjob: namespace:" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -32,7 +32,7 @@ load _helpers
 }
 
 @test "snapshotagent/cronjob: annotations:" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -44,7 +44,7 @@ load _helpers
 }
 
 @test "snapshotagent/cronjob: schedule:" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -57,7 +57,7 @@ load _helpers
 }
 
 @test "snapshot/cronjob: extraVolumes" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -70,7 +70,7 @@ load _helpers
 }
 
 @test "snapshot/cronjob: image overwrite" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -83,7 +83,7 @@ load _helpers
 }
 
 @test "snapshot/cronjob: resources" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -98,7 +98,7 @@ load _helpers
 }
 
 @test "snapshot/cronjob: configuration: s3CredentialsSecret" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -118,7 +118,7 @@ load _helpers
 }
 
 @test "snapshot/serviceaccount: disabled" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -130,7 +130,7 @@ load _helpers
 }
 
 @test "snapshot/serviceaccount: own name" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-cronjob.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -143,7 +143,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: s3Host" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -155,7 +155,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: s3Bucket" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -167,7 +167,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: s3Uri" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -179,7 +179,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: s3ExpireDays" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -191,7 +191,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: s3cmdExtraFlag" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -203,7 +203,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: baoAuthPath" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -215,7 +215,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: baoRole" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(
     helm template \
       --show-only templates/snapshotagent-configmap.yaml \
@@ -229,7 +229,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: baoAddr" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \
@@ -240,7 +240,7 @@ load _helpers
 }
 
 @test "snapshot/configmap: configuration: externalBaoAddr" {
-  cd $(chart_dir)
+  cd `chart_dir`
   local actual=$(helm template \
     --show-only templates/snapshotagent-configmap.yaml \
     --set 'snapshotAgent.enabled=true' \


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

Addin gresources to the snapshotAgent CronJob.

<!-- Describe the changes your PR introduces here. -->

# Rationale

Fixing #121

We need resources on the CronJob as well to allow setting those.

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
