### PR TITLE
fix(snapshotAgent): don't create service account if disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.23.4
+
+- fix(snapshotAgent): don't create service account if disabled
+
 ## 0.23.3
 
 - fix(deps): switch injector to openbao-k8s with patched golang.org/x/crypto (CVE-2024-45337)

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.23.3
+version: 0.23.4
 appVersion: v2.4.4
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart
@@ -26,9 +26,9 @@ annotations:
   charts.openshift.io/name: Openbao
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
-    - kind: security
+    - kind: fixed
       description: |
-        fix(deps): switch injector to openbao-k8s with patched golang.org/x/crypto (CVE-2024-45337)
+        fix(snapshotAgent): don't create service account if disabled
 
 maintainers:
   - name: OpenBao

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.23.3](https://img.shields.io/badge/Version-0.23.3-informational?style=flat-square) ![AppVersion: v2.4.4](https://img.shields.io/badge/AppVersion-v2.4.4-informational?style=flat-square)
+![Version: 0.23.4](https://img.shields.io/badge/Version-0.23.4-informational?style=flat-square) ![AppVersion: v2.4.4](https://img.shields.io/badge/AppVersion-v2.4.4-informational?style=flat-square)
 
 Official OpenBao Chart
 

--- a/charts/openbao/templates/snapshotagent-serviceaccount.yaml
+++ b/charts/openbao/templates/snapshotagent-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.snapshotAgent.serviceAccount.create -}}
+{{- if and .Values.snapshotAgent.enabled .Values.snapshotAgent.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
# Description

The service account for the snapshot agent gets created even if the snapshot agent itself is disabled. Now we check if the agent is enabled as well as the existing create check. This skips creating a ServiceAccount resource when it's not necessary.

# Rationale

The service account shouldn't exist if the feature isn't in use anyway.

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.
