### PR TITLE
ci(acceptance): add gw api crds

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -17,6 +17,9 @@ jobs:
           config: test/kind/config.yaml
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
           version: v0.29.0
+      - name: Install Gateway API resources
+        run: |
+          kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
       - name: Deploy LocalStack on Kind
         run: |
           helm repo add localstack-repo https://helm.localstack.cloud


### PR DESCRIPTION


<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description
We are missing GW API CRDs in the acceptance tests, this fixes it.

# Rationale

We need the CRDs to test `HTTPRoute` and/or `TLSRoute`.
# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [ ] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [ ] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [ ] I update the changelog in `CHANGELOG.md`
- [ ] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
