### PR TITLE
fix: add appProtocol on Service ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
-## 0.25.8
+## 0.26.1
+
+- fix: add appProtocol on Service ports
+
+## 0.26.0
 
 - feat: Allow setting tolerations for snapshot-agent cronjob pod
 

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.26.0
+version: 0.26.1
 appVersion: v2.5.1
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart
@@ -28,7 +28,7 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: |
-        feat: Allow setting tolerations for snapshot-agent cronjob pod
+        fix: add appProtocol on Service ports
 maintainers:
   - name: OpenBao
     email: openbao-security@lists.openssf.org

--- a/charts/openbao/templates/server-ha-active-service.yaml
+++ b/charts/openbao/templates/server-ha-active-service.yaml
@@ -49,6 +49,7 @@ spec:
       {{- if and (.Values.server.service.activeNodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
       nodePort: {{ .Values.server.service.activeNodePort }}
       {{- end }}
+      appProtocol: {{ include "openbao.scheme" . | upper }}
     - name: https-internal
       port: 8201
       targetPort: 8201

--- a/charts/openbao/templates/server-ha-standby-service.yaml
+++ b/charts/openbao/templates/server-ha-standby-service.yaml
@@ -48,6 +48,7 @@ spec:
       {{- if and (.Values.server.service.standbyNodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
       nodePort: {{ .Values.server.service.standbyNodePort }}
       {{- end }}
+      appProtocol: {{ include "openbao.scheme" . | upper }}
     - name: https-internal
       port: 8201
       targetPort: 8201

--- a/charts/openbao/templates/server-headless-service.yaml
+++ b/charts/openbao/templates/server-headless-service.yaml
@@ -35,6 +35,7 @@ spec:
     - name: "{{ include "openbao.scheme" . }}"
       port: {{ .Values.server.service.port }}
       targetPort: {{ .Values.server.service.targetPort }}
+      appProtocol: {{ include "openbao.scheme" . | upper }}
     - name: https-internal
       port: 8201
       targetPort: 8201

--- a/charts/openbao/templates/server-service.yaml
+++ b/charts/openbao/templates/server-service.yaml
@@ -48,6 +48,7 @@ spec:
       {{- if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
       nodePort: {{ .Values.server.service.nodePort }}
       {{- end }}
+      appProtocol: {{ include "openbao.scheme" . | upper }}
     - name: https-internal
       port: 8201
       targetPort: 8201


### PR DESCRIPTION
# Description

Add `appProtocol: {HTTP,HTTPS}` to Service ports.

# Rationale

`appProtocol` is required when using HTTPRoute with TLS enabled on OpenBao.

See details in #151.

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.