### PR TITLE
Make injector.external(Bao|Vault)Addr take precendence over global.external(Bao|Vault)Addr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.27.0
+
+- feat: Make injector.external(Bao|Vault)Addr take precendence over global.external(Bao|Vault)Addr
+
 ## 0.26.3
 
 - feat: Default to `runtimeDefault` Seccomp profile

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.26.3
+version: 0.27.0
 appVersion: v2.5.2
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart
@@ -28,7 +28,7 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: |
-        feat: Default to `runtimeDefault` Seccomp profile
+        feat: Make injector.external(Bao|Vault)Addr take precendence over global.external(Bao|Vault)Addr
 maintainers:
   - name: OpenBao
     email: openbao-security@lists.openssf.org

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.26.2](https://img.shields.io/badge/Version-0.26.2-informational?style=flat-square) ![AppVersion: v2.5.2](https://img.shields.io/badge/AppVersion-v2.5.2-informational?style=flat-square)
+![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![AppVersion: v2.5.2](https://img.shields.io/badge/AppVersion-v2.5.2-informational?style=flat-square)
 
 Official OpenBao Chart
 
@@ -102,7 +102,8 @@ Kubernetes: `>= 1.30.0-0`
 | injector.certs.keyName | string | `"tls.key"` |  |
 | injector.certs.secretName | string | `nil` |  |
 | injector.enabled | string | `"-"` | True if you want to enable openbao agent injection. @default: global.enabled |
-| injector.externalVaultAddr | string | `""` | Deprecated: Please use global.externalBaoAddr instead. |
+| injector.externalBaoAddr | string | `""` | External openbao server address for the injector to use. |
+| injector.externalVaultAddr | string | `""` | Deprecated: Please use injector.externalBaoAddr instead. |
 | injector.extraEnvironmentVars | object | `{}` |  |
 | injector.extraLabels | object | `{}` |  |
 | injector.failurePolicy | string | `"Ignore"` |  |

--- a/charts/openbao/templates/_helpers.tpl
+++ b/charts/openbao/templates/_helpers.tpl
@@ -53,6 +53,20 @@ Compute if the csi driver is enabled.
 {{- end -}}
 
 {{/*
+Resolve the external OpenBao/Vault address if the injector in order of precedence:
+1. injector.externalBaoAddr
+2. injector.externalVaultAddr
+*/}}
+
+{{- define "openbao.injector.externalAddr" -}}
+  {{- if .Values.injector.externalBaoAddr -}}
+    {{- .Values.injector.externalBaoAddr -}}
+  {{- else -}}
+    {{- .Values.injector.externalVaultAddr -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Compute if the injector is enabled.
 */}}
 {{- define "openbao.injectorEnabled" -}}
@@ -145,7 +159,7 @@ Resolve the external OpenBao/Vault address by checking global and injector value
 2. global.externalVaultAddr 
 */}}
 
-{{- define "openbao.externalAddr" -}}
+{{- define "openbao.global.externalAddr" -}}
   {{- if .Values.global.externalBaoAddr -}}
     {{- .Values.global.externalBaoAddr -}}
   {{- else -}}
@@ -159,7 +173,7 @@ template logic.
 */}}
 {{- define "openbao.mode" -}}
   {{- template "openbao.serverEnabled" . -}}
-  {{- if or (.Values.injector.externalVaultAddr) (.Values.global.externalVaultAddr) (.Values.global.externalBaoAddr) -}}
+  {{- if or (.Values.global.externalVaultAddr) (.Values.global.externalBaoAddr) -}}
     {{- $_ := set . "mode" "external" -}}
   {{- else if not .serverEnabled -}}
     {{- $_ := set . "mode" "external" -}}

--- a/charts/openbao/templates/csi-agent-configmap.yaml
+++ b/charts/openbao/templates/csi-agent-configmap.yaml
@@ -18,8 +18,8 @@ metadata:
 data:
   config.hcl: |
     vault {
-        {{- if include "openbao.externalAddr" . }}
-        "address" = "{{ include "openbao.externalAddr" . }}"
+        {{- if include "openbao.global.externalAddr" . }}
+        "address" = "{{ include "openbao.global.externalAddr" . }}"
         {{- else }}
         "address" = "{{ include "openbao.scheme" . }}://{{ template "openbao.fullname" . }}.{{ include "openbao.namespace" . }}.svc:{{ .Values.server.service.port }}"
         {{- end }}

--- a/charts/openbao/templates/csi-daemonset.yaml
+++ b/charts/openbao/templates/csi-daemonset.yaml
@@ -68,8 +68,8 @@ spec:
             - name: VAULT_ADDR
             {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
               value: "unix:///var/run/vault/agent.sock"
-            {{- else if include "openbao.externalAddr" . }}
-              value: "{{ include "openbao.externalAddr" . }}"
+            {{- else if include "openbao.global.externalAddr" . }}
+              value: "{{ include "openbao.global.externalAddr" . }}"
             {{- else }}
               value: "{{ include "openbao.scheme" . }}://{{ template "openbao.fullname" . }}.{{ include "openbao.namespace" . }}.svc:{{ .Values.server.service.port }}"
             {{- end }}

--- a/charts/openbao/templates/injector-deployment.yaml
+++ b/charts/openbao/templates/injector-deployment.yaml
@@ -59,10 +59,10 @@ spec:
             - name: AGENT_INJECT_LOG_LEVEL
               value: {{ .Values.injector.logLevel | default "info" }}
             - name: AGENT_INJECT_VAULT_ADDR
-            {{- if include "openbao.externalAddr" . }}
-              value: "{{ include "openbao.externalAddr" . }}"
-            {{- else if .Values.injector.externalVaultAddr }}
-              value: "{{ .Values.injector.externalVaultAddr }}"
+            {{- if include "openbao.injector.externalAddr" . }}
+              value: "{{ include "openbao.injector.externalAddr" . }}"
+            {{- else if include "openbao.global.externalAddr" . }}
+              value: "{{ include "openbao.global.externalAddr" . }}"
             {{- else }}
               value: {{ include "openbao.scheme" . }}://{{ template "openbao.fullname" . }}.{{ include "openbao.namespace" . }}.svc:{{ .Values.server.service.port }}
             {{- end }}

--- a/charts/openbao/templates/snapshotagent-configmap.yaml
+++ b/charts/openbao/templates/snapshotagent-configmap.yaml
@@ -21,8 +21,8 @@ data:
   S3_EXPIRE_DAYS: {{ .Values.snapshotAgent.config.s3ExpireDays | quote }}
   BAO_AUTH_PATH: {{ .Values.snapshotAgent.config.baoAuthPath }}
   BAO_ROLE: {{ .Values.snapshotAgent.config.baoRole }}
-  {{- if include "openbao.externalAddr" . }}
-  BAO_ADDR: "{{ include "openbao.externalAddr" . }}"
+  {{- if include "openbao.global.externalAddr" . }}
+  BAO_ADDR: "{{ include "openbao.global.externalAddr" . }}"
   {{- else if and (eq .mode "ha") (eq (.Values.server.service.active.enabled | toString) "true")}}
   BAO_ADDR: {{ include "openbao.scheme" . }}://{{ template "openbao.fullname" . }}-active.{{ include "openbao.namespace" . }}.svc:{{ .Values.server.service.port }}
   {{- else }}

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -63,8 +63,10 @@ injector:
   metrics:
     enabled: false
 
-  # -- Deprecated: Please use global.externalBaoAddr instead.
+  # -- Deprecated: Please use injector.externalBaoAddr instead.
   externalVaultAddr: ""
+  # -- External openbao server address for the injector to use.
+  externalBaoAddr: ""
 
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -268,7 +268,7 @@ load _helpers
   [ "${value}" = "http://global-openbao-outside" ]
 }
 
-@test "injector/deployment: global.externalVaultAddr takes precendence over injector.externalVaultAddr" {
+@test "injector/deployment: injector.externalVaultAddr takes precendence over global.externalVaultAddr" {
   cd `chart_dir`
   local object=$(helm template \
       --show-only templates/injector-deployment.yaml  \
@@ -279,10 +279,10 @@ load _helpers
 
   local value=$(echo $object |
       yq -r 'map(select(.name=="AGENT_INJECT_VAULT_ADDR")) | .[] .value' | tee /dev/stderr)
-  [ "${value}" = "http://global-openbao-outside" ]
+  [ "${value}" = "http://injector-openbao-outside" ]
 }
 
-@test "injector/deployment: global.externalBaoAddr takes precendence over injector.externalVaultAddr" {
+@test "injector/deployment: injector.externalVaultAddr takes precendence over global.externalBaoAddr" {
   cd `chart_dir`
   local object=$(helm template \
       --show-only templates/injector-deployment.yaml  \
@@ -293,7 +293,7 @@ load _helpers
 
   local value=$(echo $object |
       yq -r 'map(select(.name=="AGENT_INJECT_VAULT_ADDR")) | .[] .value' | tee /dev/stderr)
-  [ "${value}" = "http://global-openbao-outside" ]
+  [ "${value}" = "http://injector-openbao-outside" ]
 }
 
 @test "injector/deployment: without externalBaoAddr" {

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -282,12 +282,12 @@ load _helpers
   [ "${value}" = "http://injector-openbao-outside" ]
 }
 
-@test "injector/deployment: injector.externalVaultAddr takes precendence over global.externalBaoAddr" {
+@test "injector/deployment: injector.externalBaoAddr takes precendence over global.externalBaoAddr" {
   cd `chart_dir`
   local object=$(helm template \
       --show-only templates/injector-deployment.yaml  \
       --set 'global.externalBaoAddr=http://global-openbao-outside' \
-      --set 'injector.externalVaultAddr=http://injector-openbao-outside' \
+      --set 'injector.externalBaoAddr=http://injector-openbao-outside' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -296,6 +296,20 @@ load _helpers
   [ "${value}" = "http://injector-openbao-outside" ]
 }
 
+@test "injector/deployment: injector.externalBaoAddr takes precendence over injector.externalVaultAddr" {
+  cd $(chart_dir)
+  local object=$(helm template \
+    --show-only templates/injector-deployment.yaml \
+    --set 'injector.externalBaoAddr=http://injector-openbao-outside' \
+    --set 'injector.externalVaultAddr=http://injector-vault-outside' \
+    . | tee /dev/stderr |
+    yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local value=$(echo $object |
+    yq -r 'map(select(.name=="AGENT_INJECT_VAULT_ADDR")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "http://injector-openbao-outside" ]
+}
+
 @test "injector/deployment: without externalBaoAddr" {
   cd `chart_dir`
   local object=$(helm template \

--- a/test/unit/server-backendtlspolicy.bats
+++ b/test/unit/server-backendtlspolicy.bats
@@ -45,13 +45,13 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/gateway/tlspolicy: disable by injector.externalVaultAddr" {
+@test "server/gateway/tlspolicy: disable by global.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-backendtlspolicy.yaml  \
       --set 'global.tlsDisable=false' \
       --set 'server.gateway.tlsPolicy.enabled=true' \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -130,11 +130,11 @@ load _helpers
   [ ! -z "${actual}" ]
 }
 
-@test "server/ConfigMap: disabled by injector.externalVaultAddr" {
+@test "server/ConfigMap: disabled by global.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-config-configmap.yaml \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -23,11 +23,11 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/dev-StatefulSet: disable with injector.externalVaultAddr" {
+@test "server/dev-StatefulSet: disable with global.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-statefulset.yaml  \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       --set 'server.dev.enabled=true' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -23,11 +23,11 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/ha-StatefulSet: disable with injector.externalVaultAddr" {
+@test "server/ha-StatefulSet: disable with global.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-statefulset.yaml  \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       --set 'server.ha.enabled=true' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/server-httproute.bats
+++ b/test/unit/server-httproute.bats
@@ -40,12 +40,12 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "server/gateway/httproute: disable by injector.externalVaultAddr" {
+@test "server/gateway/httproute: disable by global.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-httproute.yaml  \
       --set 'server.gateway.httpRoute.enabled=true' \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -30,12 +30,12 @@ load _helpers
   [ "${actual}" = "bar" ]
 }
 
-@test "server/ingress: disable by injector.externalVaultAddr" {
+@test "server/ingress: disable by global.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-ingress.yaml  \
       --set 'server.ingress.enabled=true' \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/test/unit/server-route.bats
+++ b/test/unit/server-route.bats
@@ -12,13 +12,13 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/route: OpenShift -disable by injector.externalVaultAddr" {
+@test "server/route: OpenShift -disable by global.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-route.yaml  \
       --set 'global.openshift=true' \
       --set 'server.route.enabled=true' \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -132,12 +132,12 @@ load _helpers
   [ "${actual}" = "bar" ]
 }
 
-@test "server/Service: disable with injector.externalVaultAddr" {
+@test "server/Service: disable with global.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-service.yaml  \
       --set 'server.dev.enabled=true' \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       --set 'server.service.enabled=true' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -146,7 +146,7 @@ load _helpers
   local actual=$( (helm template \
       --show-only templates/server-service.yaml  \
       --set 'server.ha.enabled=true' \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       --set 'server.service.enabled=true' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -155,7 +155,7 @@ load _helpers
   local actual=$( (helm template \
       --show-only templates/server-service.yaml  \
       --set 'server.standalone.enabled=true' \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       --set 'server.service.enabled=true' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -110,12 +110,12 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/ServiceAccount: disable by injector.externalVaultAddr" {
+@test "server/ServiceAccount: disable by global.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-service.yaml  \
       --set 'server.dev.enabled=true' \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
@@ -123,7 +123,7 @@ load _helpers
   local actual=$( (helm template \
       --show-only templates/server-service.yaml  \
       --set 'server.ha.enabled=true' \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
@@ -131,7 +131,7 @@ load _helpers
   local actual=$( (helm template \
       --show-only templates/server-service.yaml  \
       --set 'server.standalone.enabled=true' \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -67,11 +67,11 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/standalone-StatefulSet: disable with injector.externalVaultAddr" {
+@test "server/standalone-StatefulSet: disable with global.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-statefulset.yaml  \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       --set 'server.standalone.enabled=true' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -115,11 +115,11 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/standalone-server-test-Pod: disable with injector.externalVaultAddr" {
+@test "server/standalone-server-test-Pod: disable with global.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/tests/server-test.yaml  \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       --set 'server.standalone.enabled=true' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/test/unit/server-tlsroute.bats
+++ b/test/unit/server-tlsroute.bats
@@ -30,12 +30,12 @@ load _helpers
   [ "${actual}" = "bar" ]
 }
 
-@test "server/gateway/tlsroute: disable by injector.externalVaultAddr" {
+@test "server/gateway/tlsroute: disable by global.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-tlsroute.yaml  \
       --set 'server.gateway.tlsRoute.enabled=true' \
-      --set 'injector.externalVaultAddr=http://openbao-outside' \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]


### PR DESCRIPTION
# Description

Previously it used to be the other way around. This had multiple disadvantages:

1. More specific configuration should override broader values.
2. Setting the injector specific config (injector.external(Bao|Vault)Addr) led to server being disabled.
3. Injector cannot be configured to connected to a external (e.g. Proxy) URL while still having OpenBao run in-cluster.

# Rationale

Fixes #157.

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
