### PR TITLE
Support bearerTokenFile for ServiceMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.28.0
+
+- feat: Support bearerTokenFile for ServiceMonitor
+
 ## 0.27.0
 
 - feat: Make injector.external(Bao|Vault)Addr take precendence over global.external(Bao|Vault)Addr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - fix: add global imagePullSecret to Snapshot CronJob
 - fix(openshift): update readinessProbe to support horizontal scalability
+- feat: Support bearerTokenFile for ServiceMonitor
 
 ## 0.28.6
 

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.27.0
+version: 0.28.0
 appVersion: v2.5.2
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart
@@ -28,7 +28,7 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: |
-        feat: Make injector.external(Bao|Vault)Addr take precendence over global.external(Bao|Vault)Addr
+        feat: Support bearerTokenFile for ServiceMonitor
 maintainers:
   - name: OpenBao
     email: openbao-security@lists.openssf.org

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![AppVersion: v2.5.2](https://img.shields.io/badge/AppVersion-v2.5.2-informational?style=flat-square)
+![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![AppVersion: v2.5.2](https://img.shields.io/badge/AppVersion-v2.5.2-informational?style=flat-square)
 
 Official OpenBao Chart
 
@@ -43,7 +43,7 @@ Kubernetes: `>= 1.30.0-0`
 | csi.daemonSet.updateStrategy.maxUnavailable | string | `""` |  |
 | csi.daemonSet.updateStrategy.type | string | `"RollingUpdate"` |  |
 | csi.debug | bool | `false` |  |
-| csi.enabled | bool | `false` | True if you want to install a openbao-csi-provider daemonset.  Requires installing the secrets-store-csi-driver separately, see: https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation  With the driver and provider installed, you can mount OpenBao secrets into volumes similar to the OpenBao Agent injector, and you can also sync those secrets into Kubernetes secrets. |
+| csi.enabled | bool | `false` | True if you want to install an openbao-csi-provider daemonset.  Requires installing the secrets-store-csi-driver separately, see: https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation  With the driver and provider installed, you can mount OpenBao secrets into volumes similar to the OpenBao Agent injector, and you can also sync those secrets into Kubernetes secrets. |
 | csi.extraArgs | list | `[]` |  |
 | csi.hmacSecretName | string | `""` |  |
 | csi.image.pullPolicy | string | `"IfNotPresent"` | image pull policy to use for csi image. if tag is "latest", set to "Always" |
@@ -73,7 +73,7 @@ Kubernetes: `>= 1.30.0-0`
 | csi.volumes | list | `[]` | volumes is a list of volumes made available to all containers. These are rendered via toYaml rather than pre-processed like the extraVolumes value. The purpose is to make it easy to share volumes between containers. |
 | extraObjects | list | `[]` |  |
 | global.enabled | bool | `true` | enabled is the master enabled switch. Setting this to true or false will enable or disable all the components within this chart by default. |
-| global.externalBaoAddr | string | `""` | External openbao server address for the injector and CSI provider to use. Setting this will disable deployment of a openbao server. |
+| global.externalBaoAddr | string | `""` | External openbao server address for the injector and CSI provider to use. Setting this will disable deployment of an OpenBao server. |
 | global.externalVaultAddr | string | `""` | Deprecated: Please use global.externalBaoAddr instead. |
 | global.imagePullSecrets | list | `[]` | Image pull secret to use for registry authentication. Alternatively, the value may be specified as an array of strings. |
 | global.namespace | string | `""` | The namespace to deploy to. Defaults to the `helm` installation namespace. |
@@ -317,6 +317,7 @@ Kubernetes: `>= 1.30.0-0`
 | serverTelemetry.prometheusRules.rules | list | `[]` |  |
 | serverTelemetry.prometheusRules.selectors | object | `{}` |  |
 | serverTelemetry.serviceMonitor.authorization | object | `{}` |  |
+| serverTelemetry.serviceMonitor.bearerTokenFile | string | `nil` | bearerTokenFile defines the file to read bearer token for scraping the target. |
 | serverTelemetry.serviceMonitor.enabled | bool | `false` |  |
 | serverTelemetry.serviceMonitor.interval | string | `"30s"` |  |
 | serverTelemetry.serviceMonitor.port | string | `""` | Port which Prometheus uses when scraping metrics. If empty will use `openbao.scheme` helper for its value |

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -318,6 +318,7 @@ Kubernetes: `>= 1.30.0-0`
 | serverTelemetry.prometheusRules.rules | list | `[]` |  |
 | serverTelemetry.prometheusRules.selectors | object | `{}` |  |
 | serverTelemetry.serviceMonitor.authorization | object | `{}` |  |
+| serverTelemetry.serviceMonitor.bearerTokenFile | string | `nil` | bearerTokenFile defines the file to read bearer token for scraping the target. |
 | serverTelemetry.serviceMonitor.enabled | bool | `false` |  |
 | serverTelemetry.serviceMonitor.interval | string | `"30s"` |  |
 | serverTelemetry.serviceMonitor.port | string | `""` | Port which Prometheus uses when scraping metrics. If empty will use `openbao.scheme` helper for its value |

--- a/charts/openbao/templates/NOTES.txt
+++ b/charts/openbao/templates/NOTES.txt
@@ -16,3 +16,6 @@ Your release is named {{ .Release.Name }}. To learn more about the release, try:
 WARNING: Terminating TLS before reaching the OpenBao Server is not recommended
 and may break things like certificate authentication. Prefer usage of `TLSRoute`.
 {{- end }}
+{{- if and .Values.serverTelemetry.serviceMonitor.enabled .Values.serverTelemetry.serviceMonitor.bearerTokenFile }}
+WARNING: serverTelemetry.serviceMonitor.bearerTokenFile is deprecated, use 'serverTelemetry.serviceMonitor.authorization' instead.
+{{- end }}

--- a/charts/openbao/templates/prometheus-servicemonitor.yaml
+++ b/charts/openbao/templates/prometheus-servicemonitor.yaml
@@ -52,6 +52,9 @@ spec:
     tlsConfig:
       insecureSkipVerify: true
     {{- end }}
+    {{- if .Values.serverTelemetry.serviceMonitor.bearerTokenFile }}
+    bearerTokenFile: {{ .Values.serverTelemetry.serviceMonitor.bearerTokenFile }}
+    {{- end }}
     {{- with .Values.serverTelemetry.serviceMonitor.authorization }}
     authorization:
     {{- toYaml . | nindent 6 }}

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1451,6 +1451,9 @@ serverTelemetry:
     # authorization used for scraping the Vault metrics API.
     authorization: {}
 
+    # -- bearerTokenFile defines the file to read bearer token for scraping the target.
+    bearerTokenFile: ~
+
     # scrapeClass to be used by the serviceMonitor
     scrapeClass: ""
 

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1463,6 +1463,9 @@ serverTelemetry:
     # authorization used for scraping the Vault metrics API.
     authorization: {}
 
+    # -- bearerTokenFile defines the file to read bearer token for scraping the target.
+    bearerTokenFile: ~
+
     # scrapeClass to be used by the serviceMonitor
     scrapeClass: ""
 

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1464,6 +1464,7 @@ serverTelemetry:
     authorization: {}
 
     # -- bearerTokenFile defines the file to read bearer token for scraping the target.
+    # Deprecated: Use 'serverTelemetry.serviceMonitor.authorization'
     bearerTokenFile: ~
 
     # scrapeClass to be used by the serviceMonitor

--- a/test/unit/prometheus-servicemonitor.bats
+++ b/test/unit/prometheus-servicemonitor.bats
@@ -194,6 +194,17 @@ load _helpers
   [ "$(echo "$output" | yq -r '.spec.endpoints[0].authorization.credentials.name')" = "secretname" ]
 }
 
+@test "prometheus/ServiceMonitor-server: bearerTokenFile set" {
+  cd `chart_dir`
+  local output=$( (helm template \
+    --show-only templates/prometheus-servicemonitor.yaml \
+    --set 'serverTelemetry.serviceMonitor.enabled=true' \
+    --set 'serverTelemetry.serviceMonitor.bearerTokenFile=secureToken' \
+    .) | tee /dev/stderr)
+
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].bearerTokenFile')" = "secureToken" ]
+}
+
 @test "prometheus/ServiceMonitor-server: scrapeClass set" {
   cd `chart_dir`
   local output=$( (helm template \


### PR DESCRIPTION
# Description

Authenticating metric scraping to OpenBao might require a OpenBao token. Injecting it into (my case) Grafana Alloy is possible with the Agent injector. To actually use the token, we need to be able to specify the usage on the ServiceMonitor.

# Rationale

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
