### PR TITLE
chore: bump openbao-ubi to 2.5.3 and vault-k8s to 1.7.2-ubi for oscp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## 0.28.1
+
+- chore: Update to openbao-ubi 2.5.3 for OpenShift
+- chore: Update to vault-k8s 1.7.2-ubi for OpenShift
+
 ## 0.28.0
 
 - feat(server): template `extraContainers` and `extraInitContainers`

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.28.0
+version: 0.28.1
 appVersion: v2.5.3
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart
@@ -24,11 +24,14 @@ sources:
   - https://github.com/openbao/openbao-helm
 annotations:
   charts.openshift.io/name: Openbao
-  artifacthub.io/containsSecurityUpdates: "false"
+  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        feat(server): template `extraContainers` and `extraInitContainers`
+        chore: Update to openbao-ubi 2.5.3 for OpenShift
+    - kind: changed
+      description: |
+        chore: Update to vault-k8s 1.7.2-ubi for OpenShift
 maintainers:
   - name: OpenBao
     email: openbao-security@lists.openssf.org

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![AppVersion: v2.5.3](https://img.shields.io/badge/AppVersion-v2.5.3-informational?style=flat-square)
+![Version: 0.28.1](https://img.shields.io/badge/Version-0.28.1-informational?style=flat-square) ![AppVersion: v2.5.3](https://img.shields.io/badge/AppVersion-v2.5.3-informational?style=flat-square)
 
 Official OpenBao Chart
 

--- a/charts/openbao/values.openshift.yaml
+++ b/charts/openbao/values.openshift.yaml
@@ -9,12 +9,12 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.3.1-ubi"
+    tag: "1.7.2-ubi"
 
   agentImage:
     registry: "quay.io"
     repository: "openbao/openbao-ubi"
-    tag: "2.3.2"
+    tag: "2.5.3"
     # Use UBI-based OpenBao image for better OpenShift compatibility
     # See: https://openbao.org/docs/install/#container-registries
 
@@ -22,7 +22,7 @@ server:
   image:
     registry: "quay.io"
     repository: "openbao/openbao-ubi"
-    tag: "2.3.2"
+    tag: "2.5.3"
     # Use UBI-based OpenBao image for better OpenShift compatibility
     # See: https://openbao.org/docs/install/#container-registries
 


### PR DESCRIPTION
# Description

Looks like we missed bumping the OpenShift values recently.

# Rationale

Keep the OpenShift-specific values up to date, or consider removing the file in the future if not needed.

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.