### PR TITLE
fix: Add global imagePullSecrets to Snapshot CronJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- fix: add global imagePullSecret to Snapshot CronJob
+
 ## 0.27.2
 
 - chore: update to openbao 2.5.3

--- a/charts/openbao/templates/snapshotagent-cronjob.yaml
+++ b/charts/openbao/templates/snapshotagent-cronjob.yaml
@@ -64,5 +64,5 @@ spec:
           {{- if .Values.snapshotAgent.extraVolumes }}
             {{- toYaml .Values.snapshotAgent.extraVolumes | nindent 10 }}
           {{- end }}
-          {{- include "imagePullSecrets" . | nindent 6 }}
+          {{- include "imagePullSecrets" . | nindent 10 }}
 {{ end }}

--- a/charts/openbao/templates/snapshotagent-cronjob.yaml
+++ b/charts/openbao/templates/snapshotagent-cronjob.yaml
@@ -64,4 +64,5 @@ spec:
           {{- if .Values.snapshotAgent.extraVolumes }}
             {{- toYaml .Values.snapshotAgent.extraVolumes | nindent 10 }}
           {{- end }}
+          {{- include "imagePullSecrets" . | nindent 6 }}
 {{ end }}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

<!-- Describe the changes your PR introduces here. -->

The global imagePullSecret was not used in the CronJob. This leads to errors when auth against a registry is needed

# Rationale

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

It is not big enought for a seperate patch-release and can be released with another one.

- [X] This PR contains a description of the changes I'm making
- [X] I read the `CONTRIBUTING.md` guide
- [ -] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [ -] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [X] I update the changelog in `CHANGELOG.md`
- [- ] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [ X] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
