### PR TITLE
chore/change releasing strategy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,8 +27,6 @@
 
 - [ ] This PR contains a description of the changes I'm making
 - [ ] I read the `CONTRIBUTING.md` guide
-- [ ] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
-- [ ] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
 - [ ] I update the changelog in `CHANGELOG.md`
 - [ ] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
 - [ ] By contributing this change, I certify I have signed-off on the

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -2,29 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      # Defaults to publishing draft releases.
-      # Review draft before formally releasing!
-      draft:
-        description: "Create a release draft"
-        required: false
-        default: true
-        type: boolean
-      prerelease:
-        description: "Mark this release as a prerelease"
-        required: false
-        default: "auto"
-        type: choice
-        # auto follows semver. Prerelease versions are hyphenated with a label. ex. 0.0.0-alpha, 1.0.0-rc1
-        options:
-          - auto
-          - "true"
-          - "false"
-      make-latest:
-        description: "Latest release"
-        required: false
-        default: true
-        type: boolean
 
 jobs:
   check-versions:

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -2,11 +2,29 @@ name: Release
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'charts/**'
+    inputs:
+      # Defaults to publishing draft releases.
+      # Review draft before formally releasing!
+      draft:
+        description: "Create a release draft"
+        required: false
+        default: true
+        type: boolean
+      prerelease:
+        description: "Mark this release as a prerelease"
+        required: false
+        default: "auto"
+        type: choice
+        # auto follows semver. Prerelease versions are hyphenated with a label. ex. 0.0.0-alpha, 1.0.0-rc1
+        options:
+          - auto
+          - "true"
+          - "false"
+      make-latest:
+        description: "Latest release"
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   check-versions:


### PR DESCRIPTION
# Description
@pree @nerkho

I want to adjust the Releasing of the Chart.

I'm adopting the same release strategy we have for a.e. openbao-csi-provider.


<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->


<!-- Describe the changes your PR introduces here. -->

# Rationale
My thinking here is let PR be easier to merge into "Unreleased changes" and release them with one PR that than can be triggered by workflow manually.

WDYT? This would remove the need for every PR to be "linear" to history, adjust the Chart Versioning and also changes in the Chart.yaml

We would just need to make sure to release often.

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [ ] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [ ] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [ ] I update the changelog in `CHANGELOG.md`
- [ ] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
