### PR TITLE
fix: switch to certified red hat registry images for openshift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.28.2
+
+- fix: Switch to certified Red Hat registry images for OpenShift
+
 ## 0.28.1
 
 - chore: Update to openbao-ubi 2.5.3 for OpenShift

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.28.1
+version: 0.28.2
 appVersion: v2.5.3
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart
@@ -24,14 +24,11 @@ sources:
   - https://github.com/openbao/openbao-helm
 annotations:
   charts.openshift.io/name: Openbao
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        chore: Update to openbao-ubi 2.5.3 for OpenShift
-    - kind: changed
-      description: |
-        chore: Update to vault-k8s 1.7.2-ubi for OpenShift
+        fix: Switch to certified Red Hat registry images for OpenShift
 maintainers:
   - name: OpenBao
     email: openbao-security@lists.openssf.org

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.28.1](https://img.shields.io/badge/Version-0.28.1-informational?style=flat-square) ![AppVersion: v2.5.3](https://img.shields.io/badge/AppVersion-v2.5.3-informational?style=flat-square)
+![Version: 0.28.2](https://img.shields.io/badge/Version-0.28.2-informational?style=flat-square) ![AppVersion: v2.5.3](https://img.shields.io/badge/AppVersion-v2.5.3-informational?style=flat-square)
 
 Official OpenBao Chart
 

--- a/charts/openbao/values.openshift.yaml
+++ b/charts/openbao/values.openshift.yaml
@@ -8,22 +8,21 @@ global:
 
 injector:
   image:
-    repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
+    registry: "registry.connect.redhat.com"
+    repository: "hashicorp/vault-k8s"
     tag: "1.7.2-ubi"
 
   agentImage:
-    registry: "quay.io"
+    registry: "registry.connect.redhat.com"
     repository: "openbao/openbao-ubi"
-    tag: "2.5.3"
-    # Use UBI-based OpenBao image for better OpenShift compatibility
+    # Use the certified OpenBao UBI image for better OpenShift compatibility
     # See: https://openbao.org/docs/install/#container-registries
 
 server:
   image:
-    registry: "quay.io"
+    registry: "registry.connect.redhat.com"
     repository: "openbao/openbao-ubi"
-    tag: "2.5.3"
-    # Use UBI-based OpenBao image for better OpenShift compatibility
+    # Use the certified OpenBao UBI image for better OpenShift compatibility
     # See: https://openbao.org/docs/install/#container-registries
 
   readinessProbe:


### PR DESCRIPTION
# Description

In `values.openshift.yaml`, we did not segregate `registry` and `repository` which led to various errors in Red Hat's chart-verifier.

The OpenBao UBI images are now published also in the Red Hat container registry, thus we should adopt those.

# Rationale

Ensure the deployment on OpenShift is as streamlined as possible.

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
