### PR TITLE
feat: apply server.statefulset.securityContext on helm test pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- feat: apply server.statefulset.securityContext on helm test pod
+
 ## 0.28.2
 
 - fix: Switch to certified Red Hat registry images for OpenShift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - fix: add global imagePullSecret to Snapshot CronJob
 - fix(openshift): update readinessProbe to support horizontal scalability
+- feat: apply server.statefulset.securityContext on helm test pod
 
 ## 0.28.6
 

--- a/charts/openbao/templates/_helpers.tpl
+++ b/charts/openbao/templates/_helpers.tpl
@@ -628,6 +628,47 @@ securityContext for the statefulset openbao container
 {{- end -}}
 
 {{/*
+securityContext for the server test pod template.
+*/}}
+{{- define "serverTest.statefulSet.securityContext.pod" -}}
+  {{- if .Values.server.statefulSet.securityContext.pod }}
+  securityContext:
+    {{- $tp := typeOf .Values.server.statefulSet.securityContext.pod }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.statefulSet.securityContext.pod . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.statefulSet.securityContext.pod | nindent 4 }}
+    {{- end }}
+  {{- else if not .Values.global.openshift }}
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+    runAsNonRoot: true
+    runAsGroup: {{ .Values.server.gid | default 1000 }}
+    runAsUser: {{ .Values.server.uid | default 100 }}
+    fsGroup: {{ .Values.server.gid | default 1000 }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+securityContext for the server test pod openbao container
+*/}}
+{{- define "serverTest.statefulSet.securityContext.container" -}}
+  {{- if .Values.server.statefulSet.securityContext.container }}
+      securityContext:
+        {{- $tp := typeOf .Values.server.statefulSet.securityContext.container }}
+        {{- if eq $tp "string" }}
+          {{- tpl .Values.server.statefulSet.securityContext.container . | nindent 8 }}
+        {{- else }}
+          {{- toYaml .Values.server.statefulSet.securityContext.container | nindent 8 }}
+        {{- end }}
+  {{- else if not .Values.global.openshift }}
+      securityContext:
+        allowPrivilegeEscalation: false
+  {{- end }}
+{{- end -}}
+
+{{/*
 Sets extra injector service account annotations
 */}}
 {{- define "injector.serviceAccount.annotations" -}}

--- a/charts/openbao/templates/tests/server-test.yaml
+++ b/charts/openbao/templates/tests/server-test.yaml
@@ -15,10 +15,11 @@ metadata:
     "helm.sh/hook": test
 spec:
   {{- include "imagePullSecrets" . | nindent 2 }}
-  {{- template "server.statefulSet.securityContext.pod" . }}
+  {{- template "serverTest.statefulSet.securityContext.pod" .}}
   containers:
     - name: {{ .Release.Name }}-server-test
       image: {{ .Values.server.image.registry | default "docker.io" }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default (trimPrefix "v" .Chart.AppVersion) }}
+      {{- template "serverTest.statefulSet.securityContext.container" .}}
       imagePullPolicy: {{ .Values.server.image.pullPolicy }}
       env:
         - name: VAULT_ADDR
@@ -48,7 +49,6 @@ spec:
         {{- if .Values.server.volumeMounts }}
           {{- toYaml .Values.server.volumeMounts | nindent 8}}
         {{- end }}
-      {{- template "server.statefulSet.securityContext.container" . }}
   volumes:
     {{- if .Values.server.volumes }}
       {{- toYaml .Values.server.volumes | nindent 4}}

--- a/charts/openbao/templates/tests/server-test.yaml
+++ b/charts/openbao/templates/tests/server-test.yaml
@@ -15,6 +15,7 @@ metadata:
     "helm.sh/hook": test
 spec:
   {{- include "imagePullSecrets" . | nindent 2 }}
+  {{- template "server.statefulSet.securityContext.pod" . }}
   containers:
     - name: {{ .Release.Name }}-server-test
       image: {{ .Values.server.image.registry | default "docker.io" }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default (trimPrefix "v" .Chart.AppVersion) }}
@@ -47,6 +48,7 @@ spec:
         {{- if .Values.server.volumeMounts }}
           {{- toYaml .Values.server.volumeMounts | nindent 8}}
         {{- end }}
+      {{- template "server.statefulSet.securityContext.pod" . }}
   volumes:
     {{- if .Values.server.volumes }}
       {{- toYaml .Values.server.volumes | nindent 4}}

--- a/charts/openbao/templates/tests/server-test.yaml
+++ b/charts/openbao/templates/tests/server-test.yaml
@@ -48,7 +48,7 @@ spec:
         {{- if .Values.server.volumeMounts }}
           {{- toYaml .Values.server.volumeMounts | nindent 8}}
         {{- end }}
-      {{- template "server.statefulSet.securityContext.pod" . }}
+      {{- template "server.statefulSet.securityContext.container" . }}
   volumes:
     {{- if .Values.server.volumes }}
       {{- toYaml .Values.server.volumes | nindent 4}}


### PR DESCRIPTION

# Description

As seen in https://github.com/openbao/openbao-helm/issues/154, some tools such as Kustomize will automatically template and run the `helm test` as part of their default settings.

On clusters where the security policies are stricter, this causes an issue because we don't reflect the securityContext of the server sts to the test pod.

This can wait on https://github.com/openbao/openbao-helm/pull/180, so I will not bump the version.

# Rationale

This simply adds `server.statefulSet.securityContext.pod` and `server.statefulSet.securityContext.pod` to the test pod in https://github.com/openbao/openbao-helm/tree/main/charts/openbao/templates/tests. I don't think we need additional dedicated keys for this in our value file.

Most tolls will probably allow skipping `helm test`, but that way users who want to run them can still do so.

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

