### PR TITLE
fix(chart): duplicate backendtlspolicy hostname rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - feat: Support bearerTokenFile for ServiceMonitor
 - fix(openshift): use non certified quay.io ubi container image
 - chore: update to openbao-csi-provider 2.0.3
+- fix(chart): preserve custom BackendTLSPolicy validation hostname
 
 ## 0.28.6
 

--- a/charts/openbao/templates/server-backendtlspolicy.yaml
+++ b/charts/openbao/templates/server-backendtlspolicy.yaml
@@ -37,7 +37,9 @@ spec:
     {{- with .Values.server.gateway.tlsPolicy.validation }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- if not .Values.server.gateway.tlsPolicy.validation.hostname }}
     hostname: {{ include "openbao.fullname" . }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/test/unit/server-backendtlspolicy.bats
+++ b/test/unit/server-backendtlspolicy.bats
@@ -173,6 +173,21 @@ load _helpers
   [ "${actual}" = "release-name-openbao" ]
 }
 
+@test "server/gateway/tlspolicy: validation hostname can be overridden" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-backendtlspolicy.yaml \
+      --set 'global.tlsDisable=false' \
+      --set 'server.gateway.tlsPolicy.enabled=true' \
+      --set 'server.gateway.tlsPolicy.activeService=true' \
+      --set 'server.service.enabled=true' \
+      --set 'server.gateway.tlsPolicy.validation.hostname=custom.example.com' \
+      . | tee /dev/stderr |
+      yq -r '.spec.validation.hostname' | tee /dev/stderr)
+  [ "${actual}" = "custom.example.com" ]
+}
+
 @test "server/gateway/tlspolicy: validation settings" {
   cd `chart_dir`
 
@@ -202,4 +217,3 @@ load _helpers
       yq -r '.spec.targetRefs[0].name' | tee /dev/stderr)
   [ "${actual}" = "some-target" ]
 }
-

--- a/test/unit/server-backendtlspolicy.bats
+++ b/test/unit/server-backendtlspolicy.bats
@@ -217,3 +217,4 @@ load _helpers
       yq -r '.spec.targetRefs[0].name' | tee /dev/stderr)
   [ "${actual}" = "some-target" ]
 }
+


### PR DESCRIPTION
# Description

Ran into an issue with the BackendTLSPolicy when configuring `server.gateway.tlsPolicy.validation.hostname`. The chart rendered a duplicate hostname key:

```yaml
validation:
  hostname: custom.example.com
  hostname: release-name-openbao
```

With this fix, the default hostname is only rendered when no custom validation hostname is configured.

# Rationale

Backend TLS validation should use the hostname configured by the user.

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.
