### PR TITLE
fix(csi): harden csi provider security context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - ci(tests): update kubernetees version
+- fix(csi): harden CSI provider security context
 
 ## 0.28.5
 

--- a/charts/openbao/templates/_helpers.tpl
+++ b/charts/openbao/templates/_helpers.tpl
@@ -983,6 +983,18 @@ Sets CSI daemonset securityContext for container
     {{- else }}
       {{- toYaml .Values.csi.daemonSet.securityContext.container | nindent 12 }}
     {{- end }}
+  {{- else }}
+          securityContext:
+            {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
+            runAsGroup: 1000
+            {{- end }}
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
   {{- end }}
 {{- end -}}
 

--- a/charts/openbao/templates/csi-daemonset.yaml
+++ b/charts/openbao/templates/csi-daemonset.yaml
@@ -107,8 +107,13 @@ spec:
           imagePullPolicy: {{ .Values.csi.agent.image.pullPolicy }}
           {{ template "csi.agent.resources" . }}
           command:
-            - bao
+            - /bin/sh
+            - -ec
           args:
+            - |
+              umask 0007
+              exec bao "$@"
+            - bao
             - agent
             - -config=/etc/vault/config.hcl
             {{- if .Values.csi.agent.extraArgs }}

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1286,7 +1286,18 @@ csi:
     # Extra labels to attach to the openbao-csi-provider daemonSet
     # This should be a YAML map of the labels to apply to the csi provider daemonSet
     extraLabels: {}
-    # security context for the pod template and container in the csi provider daemonSet
+    # Security context for the pod template and container in the csi provider daemonSet.
+    # The default container securityContext is:
+    #   allowPrivilegeEscalation: false
+    #   readOnlyRootFilesystem: true
+    #   runAsGroup: 1000
+    #   seccompProfile:
+    #     type: RuntimeDefault
+    #   capabilities:
+    #     drop:
+    #       - ALL
+    # The provider container does not default to runAsNonRoot because it writes
+    # its socket into the shared providers hostPath.
     securityContext:
       pod: {}
       container: {}

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -770,8 +770,49 @@ load _helpers
       --show-only templates/csi-daemonset.yaml \
       --set 'csi.enabled=true' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].securityContext' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
+      yq -r '.spec.template.spec.containers[0].securityContext == {
+        "runAsGroup": 1000,
+        "allowPrivilegeEscalation": false,
+        "readOnlyRootFilesystem": true,
+        "seccompProfile": {
+          "type": "RuntimeDefault"
+        },
+        "capabilities": {
+          "drop": [
+            "ALL"
+          ]
+        }
+      }' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local run_as_non_root=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set 'csi.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].securityContext.runAsNonRoot' | tee /dev/stderr)
+  [ "${run_as_non_root}" = "null" ]
+}
+
+@test "csi/daemonset: default csi provider securityContext without agent" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set 'csi.enabled=true' \
+      --set 'csi.agent.enabled=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].securityContext == {
+        "allowPrivilegeEscalation": false,
+        "readOnlyRootFilesystem": true,
+        "seccompProfile": {
+          "type": "RuntimeDefault"
+        },
+        "capabilities": {
+          "drop": [
+            "ALL"
+          ]
+        }
+      }' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
 }
 
 @test "csi/daemonset: specify csi.daemonSet.securityContext.pod yaml" {
@@ -820,6 +861,28 @@ load _helpers
   [ "${actual}" = "2" ]
 }
 
+@test "csi/daemonset: Agent sidecar makes socket group writable" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set 'csi.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1]' | tee /dev/stderr)
+
+  local command=$(echo "${object}" |
+      yq -r '.command' | tee /dev/stderr)
+  echo "${command}" | grep "/bin/sh"
+  echo "${command}" | grep -- "-ec"
+
+  local umask_script=$(echo "${object}" |
+      yq -r '.args[0]' | tee /dev/stderr)
+  echo "${umask_script}" | grep "umask 0007"
+
+  local lifecycle=$(echo "${object}" |
+      yq -r '.lifecycle' | tee /dev/stderr)
+  [ "${lifecycle}" = "null" ]
+}
+
 @test "csi/daemonset: Agent sidecar can pass extra args" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -827,7 +890,7 @@ load _helpers
       --set 'csi.enabled=true' \
       --set 'csi.agent.extraArgs[0]=-config=extra-config.hcl' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[1].args[2]' | tee /dev/stderr)
+      yq -r '.spec.template.spec.containers[1].args[4]' | tee /dev/stderr)
   [ "${actual}" = "-config=extra-config.hcl" ]
 }
 
@@ -896,3 +959,4 @@ load _helpers
       yq -r '.limits.cpu' | tee /dev/stderr)
   [ "${value}" = "500m" ]
 }
+


### PR DESCRIPTION
# Description

Hardens the CSI provider container defaults in the Helm chart.

This now sets:

- `allowPrivilegeEscalation: false`
- `readOnlyRootFilesystem: true`
- `seccompProfile.type: RuntimeDefault`
- `capabilities.drop: ["ALL"]`

This does not set `runAsNonRoot`. The provider still needs to create its CSI socket in the shared providers hostPath, so non-root needs separate ownership handling.

The Helm chart enables the `openbao-agent` sidecar by default. After dropping all capabilities, the provider can no longer rely on root capability bypass to access the agent socket. To keep that working, the provider runs with group `1000` when the agent is enabled, and the agent starts with `umask 0007` so `/var/run/vault/agent.sock` is group-accessible.

# Rationale

Related:

- openbao/openbao-csi-provider#134
- openbao/openbao-csi-provider#133
- openbao/openbao-csi-provider#136

This aligns the Helm chart with the compatible hardening added to the standalone CSI provider manifests, without taking on the larger non-root hostPath ownership change.

Validated with:

- `helm lint charts/openbao`
- `bats test/unit/csi-daemonset.bats`
- `bats test/unit/schema.bats`
- `LOCAL_ACCEPTANCE_TESTS=true ACCEPTANCE_TESTS=acceptance/csi.bats make test-acceptance`

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [ ] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [ ] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [ ] I update the changelog in `CHANGELOG.md`
- [ ] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.