### PR TITLE
fix(openshift): update readinessProbe to support horizontal scalability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- fix(openshift): update readinessProbe to support horizontal scalability
+
 ## 0.28.3
 
 - chore: Improve OpenShift annotations

--- a/charts/openbao/values.openshift.yaml
+++ b/charts/openbao/values.openshift.yaml
@@ -26,4 +26,4 @@ server:
     # See: https://openbao.org/docs/install/#container-registries
 
   readinessProbe:
-    path: "/v1/sys/health?uninitcode=204"
+    path: "/v1/sys/health?standbyok=true&uninitcode=204"


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

With horizontal scalability we require to set `standbyok=true` to the readinessProbe's path. Otherwise it won't respond with a 2xx.


# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [ ] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [ ] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
