### PR TITLE
feat(server): add pod-scoped self-init config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.29.0
+
+- feat(server): add self-init bootstrap job mode
+
 ## 0.28.4
 
 - docs: Update commented example with missing field

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.28.4
+version: 0.29.0
 appVersion: v2.5.5
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart
@@ -25,14 +25,11 @@ sources:
 annotations:
   charts.openshift.io/name: OpenBao
   charts.openshift.io/provider: OpenBao
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: changed
+    - kind: added
       description: |
-        docs: Update commented example with missing field
-    - kind: changed
-      description: |
-        chore: bump OpenBao to v2.5.5
+        feat(server): add self-init bootstrap job mode
 maintainers:
   - name: OpenBao
     email: openbao-security@lists.openssf.org

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.28.4](https://img.shields.io/badge/Version-0.28.4-informational?style=flat-square) ![AppVersion: v2.5.5](https://img.shields.io/badge/AppVersion-v2.5.5-informational?style=flat-square)
+![Version: 0.29.0](https://img.shields.io/badge/Version-0.29.0-informational?style=flat-square) ![AppVersion: v2.5.5](https://img.shields.io/badge/AppVersion-v2.5.5-informational?style=flat-square)
 
 Official OpenBao Chart
 
@@ -215,7 +215,7 @@ Kubernetes: `>= 1.30.0-0`
 | server.ha.disruptionBudget.enabled | bool | `true` |  |
 | server.ha.disruptionBudget.maxUnavailable | string | `nil` |  |
 | server.ha.enabled | bool | `false` |  |
-| server.ha.raft.config | string | `"ui = true\n\nlistener \"tcp\" {\n  tls_disable = 1\n  address = \"[::]:8200\"\n  cluster_address = \"[::]:8201\"\n  # Enable unauthenticated metrics access (necessary for Prometheus Operator)\n  #telemetry {\n  #  unauthenticated_metrics_access = \"true\"\n  #}\n}\n\nstorage \"raft\" {\n  path = \"/openbao/data\"\n}\n\nservice_registration \"kubernetes\" {}\n"` |  |
+| server.ha.raft.config | string | `"ui = true\n\nlistener \"tcp\" {\n  tls_disable = 1\n  address = \"[::]:8200\"\n  cluster_address = \"[::]:8201\"\n  # Enable unauthenticated metrics access (necessary for Prometheus Operator)\n  #telemetry {\n  #  unauthenticated_metrics_access = \"true\"\n  #}\n}\n\nstorage \"raft\" {\n  path = \"/openbao/data\"\n  {{- include \"openbao.selfInit.raftRetryJoin\" . | nindent 10 }}\n}\n\nservice_registration \"kubernetes\" {}\n"` |  |
 | server.ha.raft.enabled | bool | `false` |  |
 | server.ha.raft.setNodeId | bool | `false` |  |
 | server.ha.replicas | int | `3` |  |
@@ -273,6 +273,18 @@ Kubernetes: `>= 1.30.0-0`
 | server.route.host | string | `"chart-example.local"` |  |
 | server.route.labels | object | `{}` |  |
 | server.route.tls.termination | string | `"passthrough"` |  |
+| server.selfInit.config | string | `""` | Configure OpenBao declarative self-initialization HCL. |
+| server.selfInit.enabled | bool | `false` | Enable OpenBao declarative self-initialization configuration. |
+| server.selfInit.job.activeDeadlineSeconds | string | `nil` | Optional Job activeDeadlineSeconds. |
+| server.selfInit.job.annotations | object | `{}` | Annotations to apply to the self-init bootstrap Job. |
+| server.selfInit.job.autopilot.deadServerLastContactThreshold | string | `"1m"` | Dead-server last-contact threshold for the generated autopilot cleanup request. |
+| server.selfInit.job.autopilot.enabled | bool | `true` | Generate an autopilot cleanup request with the self-init configuration. |
+| server.selfInit.job.autopilot.minQuorum | string | `nil` | Minimum Raft quorum for autopilot dead-server cleanup. Defaults to max(3, server.ha.replicas) when unset. |
+| server.selfInit.job.autopilot.serverStabilizationTime | string | `"10s"` | Server stabilization time for the generated autopilot cleanup request. |
+| server.selfInit.job.backoffLimit | int | `6` | Job backoff limit. |
+| server.selfInit.job.holdSeconds | int | `120` | Number of seconds the bootstrap Job keeps OpenBao running after it observes initialization, giving StatefulSet pods time to retry_join. |
+| server.selfInit.job.podAnnotations | object | `{}` | Annotations to apply to the self-init bootstrap Job pod. |
+| server.selfInit.job.ttlSecondsAfterFinished | string | `nil` | Optional Job ttlSecondsAfterFinished. Leave unset for GitOps so the completed bootstrap Job remains part of observed cluster state. |
 | server.service.active.annotations | object | `{}` |  |
 | server.service.active.enabled | bool | `true` |  |
 | server.service.active.extraLabels | object | `{}` |  |

--- a/charts/openbao/templates/_helpers.tpl
+++ b/charts/openbao/templates/_helpers.tpl
@@ -206,6 +206,19 @@ Set's the replica count based on the different modes configured by user
 {{- end -}}
 
 {{/*
+Set's the StatefulSet pod management policy. Self-init uses a temporary
+bootstrap Job, so server pods must start in parallel to avoid blocking on
+ordinal 0 while joining the bootstrap server.
+*/}}
+{{- define "openbao.serverPodManagementPolicy" -}}
+{{- if include "openbao.selfInit.job.enabled" . -}}
+Parallel
+{{- else -}}
+{{ .Values.server.podManagementPolicy }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Set's up configmap mounts if this isn't a dev deployment and the user
 defined a custom configuration.  Additionally iterates over any
 extra volumes the user may have specified (such as a secret with TLS).
@@ -1140,9 +1153,201 @@ Supported inputs are Values.ui
 {{- end -}}
 
 {{/*
+Returns true when declarative self-initialization config should be rendered.
+*/}}
+{{- define "openbao.selfInit.enabled" -}}
+{{- if and .Values.server.selfInit.enabled .Values.server.selfInit.config -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Returns true when self-init config is delivered through the bootstrap Job.
+*/}}
+{{- define "openbao.selfInit.job.enabled" -}}
+{{- if and (include "openbao.selfInit.enabled" .) (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true") -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the temporary self-init bootstrap Service.
+*/}}
+{{- define "openbao.selfInit.job.serviceName" -}}
+{{ template "openbao.fullname" . }}-self-init
+{{- end -}}
+
+{{/*
+Generation hash for the self-init bootstrap Job. The hash is based on inputs
+that affect the Job pod template so immutable Job template changes produce a
+new Job instead of patching the old one.
+*/}}
+{{- define "openbao.selfInit.job.generation" -}}
+{{- $source := dict
+  "args" (include "openbao.selfInit.job.args" .)
+  "config" (include "openbao.selfInit.job.config" .)
+  "containerSecurityContext" (include "server.statefulSet.securityContext.container" .)
+  "dataStorageMountPath" .Values.server.dataStorage.mountPath
+  "extraArgs" .Values.server.extraArgs
+  "extraEnvironmentVars" .Values.server.extraEnvironmentVars
+  "extraSecretEnvironmentVars" .Values.server.extraSecretEnvironmentVars
+  "extraVolumes" .Values.server.extraVolumes
+  "hostAliases" .Values.server.hostAliases
+  "image" .Values.server.image
+  "imagePullSecrets" (include "imagePullSecrets" .)
+  "logFormat" .Values.server.logFormat
+  "logLevel" .Values.server.logLevel
+  "openbaoScheme" (include "openbao.scheme" .)
+  "placement" (dict "affinity" .Values.server.affinity "nodeSelector" .Values.server.nodeSelector "priorityClassName" .Values.server.priorityClassName "tolerations" .Values.server.tolerations "topologySpreadConstraints" .Values.server.topologySpreadConstraints)
+  "podAnnotations" .Values.server.selfInit.job.podAnnotations
+  "podSecurityContext" (include "server.statefulSet.securityContext.pod" .)
+  "raftSetNodeId" .Values.server.ha.raft.setNodeId
+  "resources" .Values.server.resources
+  "selfInitConfig" (include "openbao.selfInit.config" .)
+  "serviceAccountName" (include "openbao.serviceAccount.name" .)
+  "servicePort" .Values.server.service.port
+  "serviceTargetPort" .Values.server.service.targetPort
+  "volumeMounts" .Values.server.volumeMounts
+  "volumes" .Values.server.volumes
+-}}
+{{- toJson $source | sha256sum | trunc 10 -}}
+{{- end -}}
+
+{{/*
+Name of the self-init bootstrap Job. The suffix avoids immutable Job template
+patches during Helm or GitOps reconciliation.
+*/}}
+{{- define "openbao.selfInit.job.name" -}}
+{{- $prefix := printf "%s-self-init" (include "openbao.fullname" .) | trunc 52 | trimSuffix "-" -}}
+{{- printf "%s-%s" $prefix (include "openbao.selfInit.job.generation" .) -}}
+{{- end -}}
+
+{{/*
+Generated Raft retry_join stanzas for self-init bootstrap Job mode.
+
+This helper must be rendered inside the storage "raft" block.
+*/}}
+{{- define "openbao.selfInit.raftRetryJoin" -}}
+{{- $root := . -}}
+{{- if include "openbao.selfInit.job.enabled" $root }}
+retry_join {
+  leader_api_addr = "{{ include "openbao.scheme" $root }}://{{ include "openbao.selfInit.job.serviceName" $root }}.{{ include "openbao.namespace" $root }}.svc:{{ $root.Values.server.service.port }}"
+}
+{{- $replicas := int (include "openbao.replicas" $root) }}
+{{- range $i := until $replicas }}
+retry_join {
+  leader_api_addr = "{{ include "openbao.scheme" $root }}://{{ include "openbao.fullname" $root }}-{{ $i }}.{{ include "openbao.fullname" $root }}-internal.{{ include "openbao.namespace" $root }}.svc:{{ $root.Values.server.service.port }}"
+}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Render the bootstrap Job's base server config without generated retry_join
+stanzas. The Job initializes an empty temporary Raft data directory; StatefulSet
+pods join the Job, not the other way around.
+*/}}
+{{- define "openbao.selfInit.job.config" -}}
+{{- $jobCtx := deepCopy . -}}
+{{- $_ := set $jobCtx.Values.server.selfInit "enabled" false -}}
+{{ tpl .Values.server.ha.raft.config $jobCtx | nindent 4 | trim }}
+{{- end -}}
+
+{{/*
+Set's the args for the self-init bootstrap Job.
+*/}}
+{{- define "openbao.selfInit.job.args" -}}
+- |
+  {{- $replicas := int (include "openbao.replicas" .) }}
+  {{- range $i := until $replicas }}
+  if BAO_ADDR="{{ include "openbao.scheme" $ }}://{{ include "openbao.fullname" $ }}-{{ $i }}.{{ include "openbao.fullname" $ }}-internal.{{ include "openbao.namespace" $ }}.svc:{{ $.Values.server.service.port }}" bao status -tls-skip-verify -format=json 2>/dev/null | grep -Eq '"initialized"[[:space:]]*:[[:space:]]*true'; then
+    echo "OpenBao is already initialized; skipping self-init bootstrap.";
+    exit 0;
+  fi;
+  {{- end }}
+  cp /openbao/config/extraconfig-from-values.hcl /tmp/storageconfig.hcl;
+  [ -s /openbao/self-init/self-init.hcl ] && cat /openbao/self-init/self-init.hcl >> /tmp/storageconfig.hcl;
+  [ -n "${HOST_IP}" ] && sed -Ei "s|HOST_IP|${HOST_IP?}|g" /tmp/storageconfig.hcl;
+  [ -n "${POD_IP}" ] && sed -Ei "s|POD_IP|${POD_IP?}|g" /tmp/storageconfig.hcl;
+  [ -n "${HOSTNAME}" ] && sed -Ei "s|HOSTNAME|${HOSTNAME?}|g" /tmp/storageconfig.hcl;
+  [ -n "${API_ADDR}" ] && sed -Ei "s|API_ADDR|${API_ADDR?}|g" /tmp/storageconfig.hcl;
+  [ -n "${TRANSIT_ADDR}" ] && sed -Ei "s|TRANSIT_ADDR|${TRANSIT_ADDR?}|g" /tmp/storageconfig.hcl;
+  [ -n "${RAFT_ADDR}" ] && sed -Ei "s|RAFT_ADDR|${RAFT_ADDR?}|g" /tmp/storageconfig.hcl;
+  /usr/local/bin/docker-entrypoint.sh bao server -config=/tmp/storageconfig.hcl {{ .Values.server.extraArgs }} &
+  pid="$!";
+  trap 'kill -TERM "${pid}" 2>/dev/null || true; wait "${pid}" 2>/dev/null || true' TERM INT;
+  until BAO_ADDR="{{ include "openbao.scheme" . }}://127.0.0.1:8200" bao status -tls-skip-verify -format=json 2>/dev/null | grep -Eq '"initialized"[[:space:]]*:[[:space:]]*true'; do
+    if ! kill -0 "${pid}" 2>/dev/null; then
+      wait "${pid}";
+      exit $?;
+    fi;
+    sleep 2;
+  done;
+  sleep {{ .Values.server.selfInit.job.holdSeconds }};
+  kill -TERM "${pid}" 2>/dev/null || true;
+  wait "${pid}" 2>/dev/null || true;
+{{- end -}}
+
+{{/*
+Validate declarative self-initialization configuration.
+*/}}
+{{- define "openbao.selfInit.validate" -}}
+  {{- if and .Values.server.selfInit.enabled .Values.server.selfInit.config (ne .mode "dev") (ne .mode "external") }}
+    {{- if not (and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true")) }}
+      {{- fail "server.selfInit.enabled requires server.ha.enabled=true and server.ha.raft.enabled=true" }}
+    {{- end }}
+    {{- if .Values.server.selfInit.job.autopilot.enabled }}
+      {{- $minQuorum := int (include "openbao.selfInit.autopilotMinQuorum" .) -}}
+      {{- if lt $minQuorum 3 }}
+        {{- fail "server.selfInit.job.autopilot.minQuorum must be at least 3" }}
+      {{- end }}
+      {{- $replicas := int (include "openbao.replicas" .) -}}
+      {{- if lt $replicas $minQuorum }}
+        {{- fail "server.selfInit.job.autopilot.minQuorum must be less than or equal to server.ha.replicas" }}
+      {{- end }}
+    {{- end }}
+    {{- if ne (typeOf .Values.server.ha.raft.config) "string" }}
+      {{- fail "server.selfInit.config requires server.ha.raft.config to be a string" }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{- define "openbao.selfInit.autopilotMinQuorum" -}}
+{{- $configured := .Values.server.selfInit.job.autopilot.minQuorum -}}
+{{- if kindIs "invalid" $configured -}}
+  {{- $replicas := int (include "openbao.replicas" .) -}}
+  {{- if lt $replicas 3 -}}3{{- else -}}{{ $replicas }}{{- end -}}
+{{- else -}}
+{{- $configured -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "openbao.selfInit.autopilotConfig" -}}
+initialize "openbao_self_init_autopilot" {
+  request "configure-autopilot" {
+    operation = "update"
+    path = "sys/storage/raft/autopilot/configuration"
+    data = {
+      cleanup_dead_servers = true
+      dead_server_last_contact_threshold = "{{ .Values.server.selfInit.job.autopilot.deadServerLastContactThreshold }}"
+      server_stabilization_time = "{{ .Values.server.selfInit.job.autopilot.serverStabilizationTime }}"
+      min_quorum = {{ include "openbao.selfInit.autopilotMinQuorum" . }}
+    }
+  }
+}
+{{- end -}}
+
+{{- define "openbao.selfInit.config" -}}
+  {{- if and .Values.server.selfInit.enabled .Values.server.selfInit.config }}
+{{- if .Values.server.selfInit.job.autopilot.enabled }}
+{{ include "openbao.selfInit.autopilotConfig" . | trim }}
+
+{{- end }}
+{{ tpl .Values.server.selfInit.config . | trim }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 config file from values
 */}}
 {{- define "openbao.config" -}}
+  {{- include "openbao.selfInit.validate" . }}
   {{- if or (eq .mode "ha") (eq .mode "standalone") }}
   {{- $type := typeOf (index .Values.server .mode).config }}
   {{- if eq $type "string" }}

--- a/charts/openbao/templates/server-config-configmap.yaml
+++ b/charts/openbao/templates/server-config-configmap.yaml
@@ -4,6 +4,7 @@ SPDX-License-Identifier: MPL-2.0
 */}}
 
 {{ template "openbao.mode" . }}
+{{- include "openbao.selfInit.validate" . }}
 {{- if ne .mode "external" }}
 {{- if .serverEnabled -}}
 {{- if ne .mode "dev" -}}

--- a/charts/openbao/templates/server-self-init-configmap.yaml
+++ b/charts/openbao/templates/server-self-init-configmap.yaml
@@ -1,0 +1,17 @@
+{{ template "openbao.mode" . }}
+{{- include "openbao.selfInit.validate" . }}
+{{- if include "openbao.selfInit.job.enabled" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "openbao.fullname" . }}-self-init-config
+  namespace: {{ include "openbao.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "openbao.chart" . }}
+    app.kubernetes.io/name: {{ include "openbao.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  self-init.hcl: |-
+    {{ include "openbao.selfInit.config" . | nindent 4 | trim }}
+{{- end }}

--- a/charts/openbao/templates/server-self-init-job-configmap.yaml
+++ b/charts/openbao/templates/server-self-init-job-configmap.yaml
@@ -1,0 +1,17 @@
+{{ template "openbao.mode" . }}
+{{- include "openbao.selfInit.validate" . }}
+{{- if include "openbao.selfInit.job.enabled" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "openbao.fullname" . }}-self-init-job-config
+  namespace: {{ include "openbao.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "openbao.chart" . }}
+    app.kubernetes.io/name: {{ include "openbao.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  extraconfig-from-values.hcl: |-
+    {{ include "openbao.selfInit.job.config" . }}
+{{- end }}

--- a/charts/openbao/templates/server-self-init-job.yaml
+++ b/charts/openbao/templates/server-self-init-job.yaml
@@ -1,0 +1,163 @@
+{{ template "openbao.mode" . }}
+{{- include "openbao.selfInit.validate" . }}
+{{- if include "openbao.selfInit.job.enabled" . -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "openbao.selfInit.job.name" . }}
+  namespace: {{ include "openbao.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "openbao.chart" . }}
+    app.kubernetes.io/name: {{ include "openbao.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    component: self-init
+    openbao.org/self-init-generation: {{ include "openbao.selfInit.job.generation" . }}
+  {{- with .Values.server.selfInit.job.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  backoffLimit: {{ .Values.server.selfInit.job.backoffLimit }}
+  {{- if .Values.server.selfInit.job.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.server.selfInit.job.activeDeadlineSeconds }}
+  {{- end }}
+  {{- if .Values.server.selfInit.job.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.server.selfInit.job.ttlSecondsAfterFinished }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: {{ include "openbao.chart" . }}
+        app.kubernetes.io/name: {{ include "openbao.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        component: self-init
+        openbao.org/self-init-generation: {{ include "openbao.selfInit.job.generation" . }}
+      {{- with .Values.server.selfInit.job.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ template "openbao.serviceAccount.name" . }}
+      {{ template "openbao.affinity" . }}
+      {{ template "openbao.topologySpreadConstraints" . }}
+      {{ template "openbao.tolerations" . }}
+      {{ template "openbao.nodeselector" . }}
+      {{- if .Values.server.priorityClassName }}
+      priorityClassName: {{ .Values.server.priorityClassName }}
+      {{- end }}
+      {{- template "server.statefulSet.securityContext.pod" . }}
+      {{- if .Values.server.hostAliases }}
+      hostAliases:
+        {{ toYaml .Values.server.hostAliases | nindent 8}}
+      {{- end }}
+      containers:
+        - name: openbao-self-init
+          {{ template "openbao.resources" . }}
+          image: "{{ .Values.server.image.registry | default "docker.io" }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default (trimPrefix "v" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+          args:
+            {{- include "openbao.selfInit.job.args" . | nindent 12 }}
+          {{- template "server.statefulSet.securityContext.container" . }}
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: BAO_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: BAO_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: BAO_ADDR
+              value: "{{ include "openbao.scheme" . }}://127.0.0.1:8200"
+            - name: BAO_API_ADDR
+              value: "{{ include "openbao.scheme" . }}://$(POD_IP):8200"
+            - name: SKIP_CHOWN
+              value: "true"
+            - name: SKIP_SETCAP
+              value: "true"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: BAO_CLUSTER_ADDR
+              value: "{{ include "openbao.scheme" . }}://$(POD_IP):8201"
+            {{- if and (eq (.Values.server.ha.raft.enabled | toString) "true") (eq (.Values.server.ha.raft.setNodeId | toString) "true") }}
+            - name: BAO_RAFT_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- end }}
+            - name: HOME
+              value: "/home/openbao"
+            {{- if .Values.server.logLevel }}
+            - name: BAO_LOG_LEVEL
+              value: "{{ .Values.server.logLevel }}"
+            {{- end }}
+            {{- if .Values.server.logFormat }}
+            - name: BAO_LOG_FORMAT
+              value: "{{ .Values.server.logFormat }}"
+            {{- end }}
+            {{- include "openbao.extraSecretEnvironmentVars" .Values.server | nindent 12 }}
+            {{- include "openbao.extraEnvironmentVars" .Values.server | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /openbao/config
+            - name: self-init-config
+              mountPath: /openbao/self-init
+              readOnly: true
+            - name: data
+              mountPath: {{ .Values.server.dataStorage.mountPath }}
+            - name: home
+              mountPath: /home/openbao
+            {{- range .Values.server.extraVolumes }}
+            - name: userconfig-{{ .name }}
+              readOnly: true
+              mountPath: {{ .path | default "/openbao/userconfig" }}/{{ .name }}
+            {{- end }}
+            {{- if .Values.server.volumeMounts }}
+            {{- toYaml .Values.server.volumeMounts | nindent 12 }}
+            {{- end }}
+          ports:
+            - containerPort: 8200
+              name: {{ include "openbao.scheme" . }}
+            - containerPort: 8201
+              name: https-internal
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "openbao.fullname" . }}-self-init-job-config
+        - name: self-init-config
+          configMap:
+            name: {{ template "openbao.fullname" . }}-self-init-config
+        - name: data
+          emptyDir: {}
+        - name: home
+          emptyDir: {}
+        {{- range .Values.server.extraVolumes }}
+        - name: userconfig-{{ .name }}
+          {{ .type }}:
+          {{- if (eq .type "configMap") }}
+            name: {{ .name }}
+          {{- else if (eq .type "secret") }}
+            secretName: {{ .name }}
+          {{- end }}
+            defaultMode: {{ .defaultMode | default 420 }}
+        {{- end }}
+        {{- if .Values.server.volumes }}
+          {{- toYaml .Values.server.volumes | nindent 8}}
+        {{- end }}
+      {{- include "imagePullSecrets" . | nindent 6 }}
+{{- end }}

--- a/charts/openbao/templates/server-self-init-service.yaml
+++ b/charts/openbao/templates/server-self-init-service.yaml
@@ -1,0 +1,31 @@
+{{ template "openbao.mode" . }}
+{{- include "openbao.selfInit.validate" . }}
+{{- if include "openbao.selfInit.job.enabled" . -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openbao.selfInit.job.serviceName" . }}
+  namespace: {{ include "openbao.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "openbao.chart" . }}
+    app.kubernetes.io/name: {{ include "openbao.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    component: self-init
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: {{ include "openbao.scheme" . }}
+      port: {{ .Values.server.service.port }}
+      targetPort: {{ .Values.server.service.targetPort }}
+      appProtocol: {{ include "openbao.scheme" . | upper }}
+    - name: https-internal
+      port: 8201
+      targetPort: 8201
+  selector:
+    app.kubernetes.io/name: {{ include "openbao.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: self-init
+    openbao.org/self-init-generation: {{ include "openbao.selfInit.job.generation" . }}
+{{- end }}

--- a/charts/openbao/templates/server-statefulset.yaml
+++ b/charts/openbao/templates/server-statefulset.yaml
@@ -4,6 +4,7 @@ SPDX-License-Identifier: MPL-2.0
 */}}
 
 {{ template "openbao.mode" . }}
+{{- include "openbao.selfInit.validate" . }}
 {{- if ne .mode "external" }}
 {{- if ne .mode "" }}
 {{- if .serverEnabled -}}
@@ -20,7 +21,7 @@ metadata:
   {{- template "openbao.statefulSet.annotations" . }}
 spec:
   serviceName: {{ template "openbao.fullname" . }}-internal
-  podManagementPolicy: {{ .Values.server.podManagementPolicy }}
+  podManagementPolicy: {{ include "openbao.serverPodManagementPolicy" . }}
   replicas: {{ template "openbao.replicas" . }}
   updateStrategy:
     type: {{ .Values.server.updateStrategyType }}

--- a/charts/openbao/values.schema.json
+++ b/charts/openbao/values.schema.json
@@ -656,6 +656,69 @@
                         }
                     }
                 },
+                "selfInit": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "job": {
+                            "type": "object",
+                            "properties": {
+                                "activeDeadlineSeconds": {
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
+                                },
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "backoffLimit": {
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "holdSeconds": {
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "autopilot": {
+                                    "type": "object",
+                                    "properties": {
+                                        "deadServerLastContactThreshold": {
+                                            "type": "string"
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "minQuorum": {
+                                            "minimum": 3,
+                                            "type": [
+                                                "null",
+                                                "integer"
+                                            ]
+                                        },
+                                        "serverStabilizationTime": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "podAnnotations": {
+                                    "type": "object"
+                                },
+                                "ttlSecondsAfterFinished": {
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
                 "enabled": {
                     "type": [
                         "boolean",

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -953,6 +953,54 @@ server:
     # Set VAULT_DEV_ROOT_TOKEN_ID value
     devRootToken: "root"
 
+  # Configure OpenBao declarative self-initialization.
+  #
+  # Self-initialization stores native OpenBao initialize stanzas in a
+  # separate ConfigMap consumed by a temporary Raft bootstrap Job. The
+  # StatefulSet joins that bootstrap server through retry_join and does not
+  # mount the self-init ConfigMap itself, keeping all StatefulSet pods identical.
+  #
+  # This requires HA Raft and auto-unseal. Auto-unseal is an OpenBao
+  # self-initialization requirement, and the chart sets StatefulSet
+  # podManagementPolicy to Parallel while self-init is enabled so pod-0 can be
+  # recreated without blocking other pods from starting.
+  #
+  # When using a custom server.ha.raft.config, include
+  # {{ include "openbao.selfInit.raftRetryJoin" . }} inside the storage "raft"
+  # block.
+  #
+  # This config must be HCL.
+  selfInit:
+    # -- Enable OpenBao declarative self-initialization configuration.
+    enabled: false
+    # -- Configure OpenBao declarative self-initialization HCL.
+    config: ""
+    job:
+      # -- Annotations to apply to the self-init bootstrap Job.
+      annotations: {}
+      # -- Annotations to apply to the self-init bootstrap Job pod.
+      podAnnotations: {}
+      # -- Number of seconds the bootstrap Job keeps OpenBao running after it
+      # observes initialization, giving StatefulSet pods time to retry_join.
+      holdSeconds: 120
+      # -- Job backoff limit.
+      backoffLimit: 6
+      # -- Optional Job activeDeadlineSeconds.
+      activeDeadlineSeconds: null
+      # -- Optional Job ttlSecondsAfterFinished. Leave unset for GitOps so the
+      # completed bootstrap Job remains part of observed cluster state.
+      ttlSecondsAfterFinished: null
+      autopilot:
+        # -- Generate an autopilot cleanup request with the self-init configuration.
+        enabled: true
+        # -- Dead-server last-contact threshold for the generated autopilot cleanup request.
+        deadServerLastContactThreshold: 1m
+        # -- Server stabilization time for the generated autopilot cleanup request.
+        serverStabilizationTime: 10s
+        # -- Minimum Raft quorum for autopilot dead-server cleanup. Defaults to
+        # max(3, server.ha.replicas) when unset.
+        minQuorum: null
+
   # Run OpenBao in "standalone" mode. This is the default mode that will deploy if
   # no arguments are given to helm. This requires a PVC for data storage to use
   # the "file" backend.  This mode is not highly available and should not be scaled
@@ -1053,6 +1101,7 @@ server:
 
         storage "raft" {
           path = "/openbao/data"
+          {{- include "openbao.selfInit.raftRetryJoin" . | nindent 10 }}
         }
 
         service_registration "kubernetes" {}

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -54,6 +54,31 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "server/ConfigMap: selfInit is disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-config-configmap.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.data["extraconfig-from-values.hcl"] | contains("initialize")' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ConfigMap: selfInit does not append templated config" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-config-configmap.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      --set 'server.selfInit.enabled=true' \
+      --set-string 'server.selfInit.config=initialize "{{ .Release.Name }}_platform_access" {}' \
+      . | tee /dev/stderr |
+      yq -r '.data["extraconfig-from-values.hcl"]' | tee /dev/stderr)
+  [[ "${actual}" == *'storage "raft"'* ]]
+  [[ "${actual}" != *'initialize "release-name_platform_access" {}'* ]]
+}
+
 
 @test "server/ConfigMap: disabled by server.dev.enabled true" {
   cd `chart_dir`

--- a/test/unit/server-self-init-configmap.bats
+++ b/test/unit/server-self-init-configmap.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+render_self_init_configmap() {
+  helm template \
+      --show-only templates/server-self-init-configmap.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      --set 'server.selfInit.enabled=true' \
+      --set-string 'server.selfInit.config=initialize "{{ .Release.Name }}_platform_access" {}' \
+      "$@" .
+}
+
+@test "server/SelfInit ConfigMap: disabled when self-init does not apply" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-self-init-configmap.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-self-init-configmap.yaml \
+      --set 'server.dev.enabled=true' \
+      --set 'server.selfInit.enabled=true' \
+      --set-string 'server.selfInit.config=initialize "platform_access" {}' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-self-init-configmap.yaml \
+      --set 'global.externalVaultAddr=http://openbao-outside' \
+      --set 'server.selfInit.enabled=true' \
+      --set-string 'server.selfInit.config=initialize "platform_access" {}' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/SelfInit ConfigMap: includes autopilot cleanup and templated config" {
+  cd `chart_dir`
+  local actual=$(render_self_init_configmap \
+      --set 'server.ha.replicas=5' \
+      --set 'server.selfInit.job.autopilot.deadServerLastContactThreshold=2m' \
+      --set 'server.selfInit.job.autopilot.serverStabilizationTime=15s' | tee /dev/stderr |
+      yq -r '.data["self-init.hcl"]' | tee /dev/stderr)
+
+  [[ "${actual}" == *'initialize "openbao_self_init_autopilot"'* ]]
+  [[ "${actual}" == *'path = "sys/storage/raft/autopilot/configuration"'* ]]
+  [[ "${actual}" == *'cleanup_dead_servers = true'* ]]
+  [[ "${actual}" == *'dead_server_last_contact_threshold = "2m"'* ]]
+  [[ "${actual}" == *'server_stabilization_time = "15s"'* ]]
+  [[ "${actual}" == *'min_quorum = 5'* ]]
+  [[ "${actual}" == *'initialize "release-name_platform_access" {}'* ]]
+}
+
+@test "server/SelfInit ConfigMap: autopilot cleanup can be overridden or skipped" {
+  cd `chart_dir`
+  local override=$(render_self_init_configmap \
+      --set 'server.ha.replicas=5' \
+      --set 'server.selfInit.job.autopilot.minQuorum=3' \
+      --set-string 'server.selfInit.config=initialize "platform_access" {}' | tee /dev/stderr |
+      yq -r '.data["self-init.hcl"]' | tee /dev/stderr)
+  [[ "${override}" == *'min_quorum = 3'* ]]
+
+  local disabled=$(render_self_init_configmap \
+      --set 'server.selfInit.job.autopilot.enabled=false' \
+      --set-string 'server.selfInit.config=initialize "platform_access" {}' | tee /dev/stderr |
+      yq -r '.data["self-init.hcl"]' | tee /dev/stderr)
+  [[ "${disabled}" != *'initialize "openbao_self_init_autopilot"'* ]]
+  [[ "${disabled}" == *'initialize "platform_access" {}'* ]]
+}
+
+@test "server/SelfInit ConfigMap: validates HA Raft configuration" {
+  cd `chart_dir`
+  run helm template \
+      --show-only templates/server-self-init-configmap.yaml \
+      --set 'server.selfInit.enabled=true' \
+      --set-string 'server.selfInit.config=initialize "platform_access" {}' \
+      .
+  [ "$status" -ne 0 ]
+  [[ "$output" == *'server.selfInit.enabled requires server.ha.enabled=true and server.ha.raft.enabled=true'* ]]
+
+  run helm template \
+      --show-only templates/server-self-init-configmap.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      --set 'server.ha.raft.config.storage=raft' \
+      --set 'server.selfInit.enabled=true' \
+      --set-string 'server.selfInit.config=initialize "platform_access" {}' \
+      .
+  [ "$status" -ne 0 ]
+  [[ "$output" == *'server.selfInit.config requires server.ha.raft.config to be a string'* ]]
+}

--- a/test/unit/server-self-init-job.bats
+++ b/test/unit/server-self-init-job.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+render_self_init() {
+  helm template \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      --set 'server.selfInit.enabled=true' \
+      --set-string 'server.selfInit.config=initialize "platform_access" {}' \
+      "$@" .
+}
+
+@test "server/SelfInit Job: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-self-init-job.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/SelfInit Job: renders GitOps-safe bootstrap resources" {
+  cd `chart_dir`
+  local job=$(render_self_init \
+      --show-only templates/server-self-init-job.yaml \
+      --set 'server.selfInit.job.holdSeconds=42' | tee /dev/stderr)
+
+  local name=$(echo "${job}" | yq -r '.metadata.name' | tee /dev/stderr)
+  [[ "${name}" =~ ^release-name-openbao-self-init-[0-9a-f]{10}$ ]]
+  [ "$(echo "${job}" | yq -r '.kind')" = "Job" ]
+  [ "$(echo "${job}" | yq -r '.spec | has("ttlSecondsAfterFinished")')" = "false" ]
+
+  local args=$(echo "${job}" | yq -r '.spec.template.spec.containers[0].args[0]' | tee /dev/stderr)
+  [[ "${args}" == *'bao server -config=/tmp/storageconfig.hcl'* ]]
+  [[ "${args}" == *'release-name-openbao-0.release-name-openbao-internal.default.svc:8200'* ]]
+  [[ "${args}" == *'skipping self-init bootstrap'* ]]
+  [[ "${args}" == *'sleep 42'* ]]
+
+  local ttl=$(render_self_init \
+      --show-only templates/server-self-init-job.yaml \
+      --set 'server.selfInit.job.ttlSecondsAfterFinished=123' | tee /dev/stderr |
+      yq -r '.spec.ttlSecondsAfterFinished' | tee /dev/stderr)
+  [ "${ttl}" = "123" ]
+
+  local changed_name=$(render_self_init \
+      --show-only templates/server-self-init-job.yaml \
+      --set-string 'server.selfInit.config=initialize "different_platform_access" {}' | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${name}" != "${changed_name}" ]
+
+  local service=$(render_self_init \
+      --show-only templates/server-self-init-service.yaml \
+      --set 'server.selfInit.job.holdSeconds=42' | tee /dev/stderr)
+  [ "$(echo "${service}" | yq -r '.spec.clusterIP')" = "None" ]
+  [ "$(echo "${service}" | yq -r '.spec.selector.component')" = "self-init" ]
+
+  local job_generation=$(echo "${job}" | yq -r '.spec.template.metadata.labels["openbao.org/self-init-generation"]')
+  local service_generation=$(echo "${service}" | yq -r '.spec.selector["openbao.org/self-init-generation"]')
+  [ "${service_generation}" = "${job_generation}" ]
+}
+
+@test "server/SelfInit Job: keeps bootstrap config separate from StatefulSet config" {
+  cd `chart_dir`
+  local job_config=$(render_self_init \
+      --show-only templates/server-self-init-job-configmap.yaml | tee /dev/stderr |
+      yq -r '.data["extraconfig-from-values.hcl"]' | tee /dev/stderr)
+  [[ "${job_config}" == *'storage "raft"'* ]]
+  [[ "${job_config}" != *'retry_join'* ]]
+  [[ "${job_config}" != *'initialize "platform_access"'* ]]
+
+  local server_config=$(render_self_init \
+      --show-only templates/server-config-configmap.yaml | tee /dev/stderr |
+      yq -r '.data["extraconfig-from-values.hcl"]' | tee /dev/stderr)
+  [[ "${server_config}" == *'leader_api_addr = "http://release-name-openbao-self-init.default.svc:8200"'* ]]
+  [[ "${server_config}" == *'leader_api_addr = "http://release-name-openbao-0.release-name-openbao-internal.default.svc:8200"'* ]]
+  [[ "${server_config}" == *'leader_api_addr = "http://release-name-openbao-2.release-name-openbao-internal.default.svc:8200"'* ]]
+  [[ "${server_config}" != *'initialize "platform_access"'* ]]
+
+  local statefulset=$(render_self_init \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.podManagementPolicy=OrderedReady' | tee /dev/stderr)
+  [ "$(echo "${statefulset}" | yq -r '.spec.podManagementPolicy')" = "Parallel" ]
+  [ "$(echo "${statefulset}" | yq -r '(.spec.template.spec.volumes // []) | map(select(.name == "self-init-config")) | length')" = "0" ]
+  [[ "$(echo "${statefulset}" | yq -r '.spec.template.spec.containers[0].args[0]')" != *'/openbao/self-init/self-init.hcl'* ]]
+}
+
+@test "server/SelfInit Job: inherits user server volumes and mounts" {
+  cd `chart_dir`
+  local job=$(render_self_init \
+      --show-only templates/server-self-init-job.yaml \
+      --set 'server.extraVolumes[0].name=seal-material' \
+      --set 'server.extraVolumes[0].type=secret' \
+      --set 'server.extraVolumes[0].path=/openbao/seal' \
+      --set 'server.volumes[0].name=custom-seal' \
+      --set 'server.volumes[0].secret.secretName=custom-seal' \
+      --set 'server.volumeMounts[0].name=custom-seal' \
+      --set 'server.volumeMounts[0].mountPath=/openbao/custom-seal' | tee /dev/stderr)
+
+  [ "$(echo "${job}" | yq -r '.spec.template.spec.volumes[] | select(.name == "userconfig-seal-material").secret.secretName')" = "seal-material" ]
+  [ "$(echo "${job}" | yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "userconfig-seal-material").mountPath')" = "/openbao/seal/seal-material" ]
+  [ "$(echo "${job}" | yq -r '.spec.template.spec.volumes[] | select(.name == "custom-seal").secret.secretName')" = "custom-seal" ]
+  [ "$(echo "${job}" | yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "custom-seal").mountPath')" = "/openbao/custom-seal" ]
+}


### PR DESCRIPTION
# Description

This adds chart-level support for pod-scoped OpenBao declarative self-initialization.

The chart now supports:

- `server.selfInit.enabled`
- `server.selfInit.targetPodOrdinal`
- `server.selfInit.config`

When enabled, the self-init HCL is rendered into a dedicated `*-self-init-config` ConfigMap and mounted into the server container. The server startup command appends that HCL to the runtime config only when the StatefulSet pod ordinal matches `server.selfInit.targetPodOrdinal`.

By default, only pod ordinal `0` receives the self-init configuration. The shared server ConfigMap remains free of self-init stanzas, so follower pods can join through the normal Raft `retry_join` flow instead of also attempting self-initialization.

# Rationale

Fixes openbao/openbao-helm#164.

Related: openbao/openbao#2274.

When `initialize` stanzas are placed in the shared server configuration for an HA Raft deployment, every pod receives the same self-init configuration. This can race with Raft `retry_join` and cause follower pods to self-initialize independently instead of joining the first node.

Scoping self-init to a single StatefulSet ordinal keeps the bootstrap path declarative while avoiding that race. It also allows `server.selfInit.enabled=true` to remain configured after first boot, because only the target pod gets the self-init HCL and OpenBao ignores self-initialization for already-initialized storage.

Validation performed:

- `helm lint .`
- `bats test/unit`
- kind smoke test with HA Raft, `replicas=3`, static auto-unseal, normal voter `retry_join`, and `server.selfInit.enabled=true`

Runtime smoke result:

- pod 0 had one self-init stanza in `/tmp/storageconfig.hcl`
- pods 1 and 2 had zero self-init stanzas
- all three pods became Ready
- Raft settled to three voters
- autopilot reported healthy with failure tolerance 1
- login via the self-init-created userpass admin succeeded


# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I updated the version in `Chart.yaml` if feasible according to [Semantic versioning](https://semver.org/)
- [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.
