### PR TITLE
Fix: Allow using custom Secret keys for Snapshot Agent S3 credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- fix: allow using custom Secret keys for Snapshot Agent S3 credentials.
 - fix: add global imagePullSecret to Snapshot CronJob
 - fix(openshift): update readinessProbe to support horizontal scalability
 - feat: apply server.statefulset.securityContext on helm test pod

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -344,7 +344,7 @@ Kubernetes: `>= 1.30.0-0`
 | snapshotAgent.image.tag | string | `"0.3.0"` |  |
 | snapshotAgent.resources | object | `{}` |  |
 | snapshotAgent.restartPolicy | string | `"OnFailure"` |  |
-| snapshotAgent.s3CredentialsSecret | string | `"my-s3-credentials"` |  |
+| snapshotAgent.s3CredentialsSecret | string | `""` | Existing Kubernetes secret with S3 Credentials. Must contain keys called AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. If not provided, you must provide `snapshotAgent.extraSecretEnvironmentVars` |
 | snapshotAgent.schedule | string | `"*/15 * * * *"` |  |
 | snapshotAgent.securityContext.container | object | `{}` |  |
 | snapshotAgent.securityContext.pod | object | `{}` |  |

--- a/charts/openbao/templates/snapshotagent-cronjob.yaml
+++ b/charts/openbao/templates/snapshotagent-cronjob.yaml
@@ -36,16 +36,18 @@ spec:
             - configMapRef:
                 name: {{ template "openbao.fullname" . }}-snapshot
             env:
+            {{- with .Values.snapshotAgent.s3CredentialsSecret }}
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   key: AWS_SECRET_ACCESS_KEY
-                  name: {{ .Values.snapshotAgent.s3CredentialsSecret }}
+                  name: {{ . }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   key: AWS_ACCESS_KEY_ID
-                  name: {{ .Values.snapshotAgent.s3CredentialsSecret }}
+                  name: {{ . }}
+            {{- end }}
             {{- include "openbao.extraSecretEnvironmentVars" .Values.snapshotAgent | nindent 12 }}
             {{- include "openbao.extraEnvironmentVars" .Values.snapshotAgent | nindent 12 }}
             image: {{ .Values.snapshotAgent.image.repository }}:{{ .Values.snapshotAgent.image.tag }}

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1571,8 +1571,10 @@ snapshotAgent:
   #     readOnly: true
   #     subPath: ca.crt
 
-  # s3CredentialsSecret to use
-  s3CredentialsSecret: "my-s3-credentials"
+  # -- Existing Kubernetes secret with S3 Credentials.
+  # Must contain keys called AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
+  # If not provided, you must provide `snapshotAgent.extraSecretEnvironmentVars`
+  s3CredentialsSecret: ""
 
   # configuration for the snapshot agent
   config:

--- a/test/unit/snapshotagent.bats
+++ b/test/unit/snapshotagent.bats
@@ -276,11 +276,11 @@ load _helpers
       yq -r '.spec.jobTemplate.spec.template.spec.containers[0].env' | tee /dev/stderr )
 
   local actual=$(echo $object |
-     yq -r '.[2].name' | tee /dev/stderr)
+     yq -r '.[0].name' | tee /dev/stderr)
   [ "${actual}" = "BAO_FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[2].value' | tee /dev/stderr)
+      yq -r '.[0].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 }
 


### PR DESCRIPTION
# Description

This changes the default values of the `snapshotAgent.s3CredentialsSecret` helm parameter to `""` and then only uses it if it's provided. It also adds documentation on how it works.

# Rationale

Currently, it's not explained that you need to provide a Kubernetes Secret with the exact keys of `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, however, just a few lines down, `snapshotAgent.extraSecretEnvironmentVars` shows the following example:

```yaml
  # --  List of extra environment variables to set in the snapshot-agent cronjob
  # These variables take value from existing Secret objects.
  extraSecretEnvironmentVars: []
  # - envName: AWS_SECRET_ACCESS_KEY
  #   secretName: openbao
  #   secretKey: AWS_SECRET_ACCESS_KEY
```

Given that, I tried to provide the following:

```yaml
# Snapshot Agent Configuration
snapshotAgent:
  # whether or not to enable the snapshot agent cronjob
  enabled: true
  # --  List of extra environment variables to set in the snapshot-agent cronjob
  # These variables take value from existing Secret objects.
  extraSecretEnvironmentVars:
    - envName: AWS_ACCESS_KEY_ID
      secretName: openbao-s3-backups-credentials
      secretKey: username
    - envName: AWS_SECRET_ACCESS_KEY
      secretName: openbao-s3-backups-credentials
      secretKey: password
```

However when the cronjob ran, it threw:

```
Warning  Failed  5m12s (x47 over 15m)   kubelet  spec.containers{bao-snapshot}: Error: couldn't find key AWS_SECRET_ACCESS_KEY in Secret openbao/openbao-s3-backups-credentials
```

Because it currently only accepts the `snapshotAgent.s3CredentialsSecret` which uses hardcoded secret keys. My change would allow people to optionally provide `snapshotAgent.s3CredentialsSecret` OR `snapshotAgent.extraSecretEnvironmentVars`.

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.