### PR TITLE
ci(tests): update kubernetes version

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.33.7, 1.34.3, 1.35.1]
+        kind-k8s-version: [1.34.9, 1.35.6, 1.36.1]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.34.9, 1.35.6, 1.36.1]
+        kind-k8s-version: [1.34.8, 1.35.5, 1.36.1]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/lint-chart.yml
+++ b/.github/workflows/lint-chart.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          node_image: kindest/node:v1.35.1
+          node_image: kindest/node:v1.36.1
           version: v0.29.0
         if: steps.list-changed.outputs.changed == 'true'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- ci(tests): update kubernetees version
+
 ## 0.28.5
 
 - chore: bump OpenBao to v2.6.0


### PR DESCRIPTION
# Description

Took the opportunity of #194 to update the Kubernetes version in our testing suite.

# Rationale

We are aligned with the Kubernetes project where only the 3 most recent releases are supported.

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.
