### PR TITLE
Feat: add configurable `snapshotAgent.s3CredentialsSecretKeys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- feat(snapshotAgent): add configurable `snapshotAgent.s3CredentialsSecretKeys`
+
 ## 0.28.5
 
 - chore: bump OpenBao to v2.6.0

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -343,7 +343,9 @@ Kubernetes: `>= 1.30.0-0`
 | snapshotAgent.image.tag | string | `"0.3.0"` |  |
 | snapshotAgent.resources | object | `{}` |  |
 | snapshotAgent.restartPolicy | string | `"OnFailure"` |  |
-| snapshotAgent.s3CredentialsSecret | string | `"my-s3-credentials"` |  |
+| snapshotAgent.s3CredentialsSecret | string | `"my-s3-credentials"` | Existing Kubernetes secret with S3 Credentials. |
+| snapshotAgent.s3CredentialsSecretKeys.awsAccessKeyID | string | `"AWS_ACCESS_KEY_ID"` | key in secret containing the S3 access key ID |
+| snapshotAgent.s3CredentialsSecretKeys.awsSecretAccessKey | string | `"AWS_SECRET_ACCESS_KEY"` | key in secret containing the S3 secret access key |
 | snapshotAgent.schedule | string | `"*/15 * * * *"` |  |
 | snapshotAgent.securityContext.container | object | `{}` |  |
 | snapshotAgent.securityContext.pod | object | `{}` |  |

--- a/charts/openbao/templates/snapshotagent-cronjob.yaml
+++ b/charts/openbao/templates/snapshotagent-cronjob.yaml
@@ -39,12 +39,12 @@ spec:
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  key: AWS_SECRET_ACCESS_KEY
+                  key: {{ .Values.snapshotAgent.s3CredentialsSecretKeys.awsSecretAccessKey }}
                   name: {{ .Values.snapshotAgent.s3CredentialsSecret }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  key: AWS_ACCESS_KEY_ID
+                  key: {{ .Values.snapshotAgent.s3CredentialsSecretKeys.awsAccessKeyID }}
                   name: {{ .Values.snapshotAgent.s3CredentialsSecret }}
             {{- include "openbao.extraSecretEnvironmentVars" .Values.snapshotAgent | nindent 12 }}
             {{- include "openbao.extraEnvironmentVars" .Values.snapshotAgent | nindent 12 }}

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1556,8 +1556,13 @@ snapshotAgent:
   #     readOnly: true
   #     subPath: ca.crt
 
-  # s3CredentialsSecret to use
+  # -- Existing Kubernetes secret with S3 Credentials.
   s3CredentialsSecret: "my-s3-credentials"
+  s3CredentialsSecretKeys:
+    # -- key in secret containing the S3 access key ID
+    awsAccessKeyID: "AWS_ACCESS_KEY_ID"
+    # -- key in secret containing the S3 secret access key
+    awsSecretAccessKey: "AWS_SECRET_ACCESS_KEY"
 
   # configuration for the snapshot agent
   config:

--- a/test/unit/snapshotagent.bats
+++ b/test/unit/snapshotagent.bats
@@ -117,6 +117,26 @@ load _helpers
   [ "${actual}" = "creds" ]
 }
 
+@test "snapshot/cronjob: configuration: s3CredentialsSecretKeys" {
+  cd `chart_dir`
+  local actual=$(helm template \
+    --show-only templates/snapshotagent-cronjob.yaml \
+    --set 'snapshotAgent.enabled=true' \
+    --set 'snapshotAgent.s3CredentialsSecretKeys.awsAccessKeyID=username' \
+    --namespace foo \
+    . | tee /dev/stderr |
+    yq -r '.spec.jobTemplate.spec.template.spec.containers[0].env[] | select(.name == "AWS_ACCESS_KEY_ID") | .valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "username" ]
+  local actual=$(helm template \
+    --show-only templates/snapshotagent-cronjob.yaml \
+    --set 'snapshotAgent.enabled=true' \
+    --set 'snapshotAgent.s3CredentialsSecretKeys.awsSecretAccessKey=password' \
+    --namespace foo \
+    . | tee /dev/stderr |
+    yq -r '.spec.jobTemplate.spec.template.spec.containers[0].env[] | select(.name == "AWS_SECRET_ACCESS_KEY") | .valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "password" ]
+}
+
 @test "snapshot/serviceaccount: disabled" {
   cd `chart_dir`
   local actual=$(helm template \


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

An alternative to #195 that introduces configurable `snapshotAgent.s3CredentialsSecretKeys`. It keeps the original defaults so that it doesn't introduce any breaking changes.

# Rationale

This lets you configure the snapshot agent's keys to use within the `snapshotAgent.s3CredentialsSecret` so that users that have secrets with alternative keys can still use the feature.

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
