### PR TITLE
ci(lint-chart): remove version increment requirement

### DIFF
--- a/.github/workflows/lint-chart.yml
+++ b/.github/workflows/lint-chart.yml
@@ -38,8 +38,7 @@ jobs:
         id: lint
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          CHECK_VERSION_INCREMENT=${{ !contains(github.event.pull_request.labels.*.name, 'no-release') }}
-          ct lint --target-branch ${{ github.event.repository.default_branch }} --check-version-increment=${CHECK_VERSION_INCREMENT}
+          ct lint --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0


### PR DESCRIPTION
# Description

As noticed in #198 and #195, our lint workflow still requires a chart version increment despite the move to a manual release process.

# Rationale

Remove the chart version increment requirement as we perform manual releases now.

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
