### PR TITLE
ci(lint-chart): adjust to check version only if label release is set

### DIFF
--- a/.github/workflows/lint-chart.yml
+++ b/.github/workflows/lint-chart.yml
@@ -38,7 +38,8 @@ jobs:
         id: lint
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          ct lint --target-branch ${{ github.event.repository.default_branch }}
+          CHECK_VERSION_INCREMENT=${{ contains(github.event.pull_request.labels.*.name, 'release') }}
+          ct lint --target-branch ${{ github.event.repository.default_branch }} --check-version-increment=${CHECK_VERSION_INCREMENT}
 
       - name: Create kind cluster
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0


### PR DESCRIPTION

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

Since changin release strategy the ci lint job is failing cause CHECK_VERSION_INCREMENT is by default true.

This changes the behaviour by inversing it. By default false, if release label is set it checks the increment (only on release PRs)


<!-- Describe the changes your PR introduces here. -->


<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
