### PR TITLE
chore: bump OpenBao to v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - chore: bump OpenBao to v2.6.1
 - fix(csi): harden CSI provider security context
-- ci(tests): update kubernetees version
+- ci(tests): update kubernetes version
 
 ## 0.28.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Unreleased
 
-- ci(tests): update kubernetees version
+## 0.28.6
+
+- chore: bump OpenBao to v2.6.1
 - fix(csi): harden CSI provider security context
+- ci(tests): update kubernetees version
 
 ## 0.28.5
 

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: openbao
-version: 0.28.5
-appVersion: v2.6.0
+version: 0.28.6
+appVersion: v2.6.1
 kubeVersion: ">= 1.30.0-0"
 description: Official OpenBao Chart
 home: https://github.com/openbao/openbao-helm
@@ -29,7 +29,13 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        chore: bump OpenBao to v2.6.0
+        chore: bump OpenBao to v2.6.1
+    - kind: changed
+      description: |
+        fix(csi): harden CSI provider security context
+    - kind: changed
+      description: |
+        ci(tests): update kubernetees version
 maintainers:
   - name: OpenBao
     email: openbao-security@lists.openssf.org

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -35,7 +35,7 @@ annotations:
         fix(csi): harden CSI provider security context
     - kind: changed
       description: |
-        ci(tests): update kubernetees version
+        ci(tests): update kubernetes version
 maintainers:
   - name: OpenBao
     email: openbao-security@lists.openssf.org

--- a/charts/openbao/Chart.yaml
+++ b/charts/openbao/Chart.yaml
@@ -30,7 +30,7 @@ annotations:
     - kind: changed
       description: |
         chore: bump OpenBao to v2.6.1
-    - kind: changed
+    - kind: fixed
       description: |
         fix(csi): harden CSI provider security context
     - kind: changed

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.28.5](https://img.shields.io/badge/Version-0.28.5-informational?style=flat-square) ![AppVersion: v2.6.0](https://img.shields.io/badge/AppVersion-v2.6.0-informational?style=flat-square)
+![Version: 0.28.6](https://img.shields.io/badge/Version-0.28.6-informational?style=flat-square) ![AppVersion: v2.6.1](https://img.shields.io/badge/AppVersion-v2.6.1-informational?style=flat-square)
 
 Official OpenBao Chart
 


### PR DESCRIPTION
# Description

Bump OpenBao to v2.6.1: https://github.com/openbao/openbao/releases/tag/v2.6.1

Additionally, include these changes in the chart release 0.28.6:
* fix(csi): harden CSI provider security context
* ci(tests): update kubernetes version

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.
