### PR TITLE
fix(openshift): use non certified quay.io ubi container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fix(openshift): update readinessProbe to support horizontal scalability
 - feat: apply server.statefulset.securityContext on helm test pod
 - feat: Support bearerTokenFile for ServiceMonitor
+- fix(openshift): use non certified quay.io ubi container image
 
 ## 0.28.6
 

--- a/charts/openbao/values.openshift.yaml
+++ b/charts/openbao/values.openshift.yaml
@@ -13,16 +13,14 @@ injector:
     tag: "1.7.2-ubi"
 
   agentImage:
-    registry: "registry.connect.redhat.com"
     repository: "openbao/openbao-ubi"
-    # Use the certified OpenBao UBI image for better OpenShift compatibility
+    # Use the OpenBao UBI image for better OpenShift compatibility
     # See: https://openbao.org/docs/install/#container-registries
 
 server:
   image:
-    registry: "registry.connect.redhat.com"
     repository: "openbao/openbao-ubi"
-    # Use the certified OpenBao UBI image for better OpenShift compatibility
+    # Use the OpenBao UBI image for better OpenShift compatibility
     # See: https://openbao.org/docs/install/#container-registries
 
   readinessProbe:


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

Due to complications with Red Hat we need to revert the change to their registry and roll back to quay.io

# Rationale

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

Fixes #202 

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
