### PR TITLE
chore(chart): remove obsolete Kubernetes API and version compatibility checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fix(openshift): use non certified quay.io ubi container image
 - chore: update to openbao-csi-provider 2.0.3
 - fix(chart): preserve custom BackendTLSPolicy validation hostname
+- chore(chart): remove obsolete Kubernetes API and version compatibility checks
 
 ## 0.28.6
 

--- a/charts/openbao/templates/injector-mutating-webhook.yaml
+++ b/charts/openbao/templates/injector-mutating-webhook.yaml
@@ -5,11 +5,7 @@ SPDX-License-Identifier: MPL-2.0
 
 {{- template "openbao.injectorEnabled" . -}}
 {{- if .injectorEnabled -}}
-{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1
-{{- else }}
-apiVersion: admissionregistration.k8s.io/v1beta1
-{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "openbao.fullname" . }}-agent-injector-cfg

--- a/charts/openbao/templates/server-clusterrolebinding.yaml
+++ b/charts/openbao/templates/server-clusterrolebinding.yaml
@@ -5,11 +5,7 @@ SPDX-License-Identifier: MPL-2.0
 
 {{ template "openbao.serverAuthDelegator" . }}
 {{- if .serverAuthDelegator -}}
-{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- end }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "openbao.fullname" . }}-server-binding

--- a/charts/openbao/templates/server-discovery-rolebinding.yaml
+++ b/charts/openbao/templates/server-discovery-rolebinding.yaml
@@ -7,11 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 {{- if .serverEnabled -}}
 {{- if eq .mode "ha" }}
 {{- if eq (.Values.server.serviceAccount.serviceDiscovery.enabled | toString) "true" }}
-{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- end }}
 kind: RoleBinding
 metadata:
   name: {{ template "openbao.fullname" . }}-discovery-rolebinding

--- a/charts/openbao/templates/server-ha-active-service.yaml
+++ b/charts/openbao/templates/server-ha-active-service.yaml
@@ -29,13 +29,11 @@ spec:
   {{- if .Values.server.service.type}}
   type: {{ .Values.server.service.type }}
   {{- end}}
-  {{- if (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) }}
   {{- if .Values.server.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.server.service.ipFamilyPolicy }}
   {{- end }}
   {{- if .Values.server.service.ipFamilies }}
   ipFamilies: {{ .Values.server.service.ipFamilies | toYaml | nindent 2 }}
-  {{- end }}
   {{- end }}
   {{- if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}

--- a/charts/openbao/templates/server-ha-standby-service.yaml
+++ b/charts/openbao/templates/server-ha-standby-service.yaml
@@ -28,13 +28,11 @@ spec:
   {{- if .Values.server.service.type}}
   type: {{ .Values.server.service.type }}
   {{- end}}
-  {{- if (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) }}
   {{- if .Values.server.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.server.service.ipFamilyPolicy }}
   {{- end }}
   {{- if .Values.server.service.ipFamilies }}
   ipFamilies: {{ .Values.server.service.ipFamilies | toYaml | nindent 2 }}
-  {{- end }}
   {{- end }}
   {{- if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}

--- a/charts/openbao/templates/server-headless-service.yaml
+++ b/charts/openbao/templates/server-headless-service.yaml
@@ -21,13 +21,11 @@ metadata:
     openbao-internal: "true"
 {{- template "openbao.service.headless.annotations" .}}
 spec:
-  {{- if (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) }}
   {{- if .Values.server.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.server.service.ipFamilyPolicy }}
   {{- end }}
   {{- if .Values.server.service.ipFamilies }}
   ipFamilies: {{ .Values.server.service.ipFamilies | toYaml | nindent 2 }}
-  {{- end }}
   {{- end }}
   clusterIP: None
   publishNotReadyAddresses: true

--- a/charts/openbao/templates/server-ingress.yaml
+++ b/charts/openbao/templates/server-ingress.yaml
@@ -15,7 +15,6 @@ SPDX-License-Identifier: MPL-2.0
 {{- end }}
 {{- $servicePort := .Values.server.service.port -}}
 {{- $pathType := .Values.server.ingress.pathType -}}
-{{- $kubeVersion := .Capabilities.KubeVersion.Version }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/openbao/templates/server-service.yaml
+++ b/charts/openbao/templates/server-service.yaml
@@ -26,13 +26,11 @@ spec:
   {{- if .Values.server.service.type}}
   type: {{ .Values.server.service.type }}
   {{- end}}
-  {{- if (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) }}
   {{- if .Values.server.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.server.service.ipFamilyPolicy }}
   {{- end }}
   {{- if .Values.server.service.ipFamilies }}
   ipFamilies: {{ .Values.server.service.ipFamilies | toYaml | nindent 2 }}
-  {{- end }}
   {{- end }}
   {{- if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}

--- a/charts/openbao/templates/server-statefulset.yaml
+++ b/charts/openbao/templates/server-statefulset.yaml
@@ -24,7 +24,7 @@ spec:
   replicas: {{ template "openbao.replicas" . }}
   updateStrategy:
     type: {{ .Values.server.updateStrategyType }}
-  {{- if and (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) (.Values.server.persistentVolumeClaimRetentionPolicy) }}
+  {{- if .Values.server.persistentVolumeClaimRetentionPolicy }}
   persistentVolumeClaimRetentionPolicy: {{ toYaml .Values.server.persistentVolumeClaimRetentionPolicy | nindent 4 }}
   {{- end }}
   selector:

--- a/charts/openbao/templates/server-tlsroute.yaml
+++ b/charts/openbao/templates/server-tlsroute.yaml
@@ -8,7 +8,6 @@
 {{- $serviceName = printf "%s-%s" $serviceName "active" -}}
 {{- end }}
 {{- $servicePort := .Values.server.service.port -}}
-{{- $kubeVersion := .Capabilities.KubeVersion.Version }}
 apiVersion: {{ .Values.server.gateway.tlsRoute.apiVersion }}
 kind: TLSRoute
 metadata:

--- a/charts/openbao/templates/ui-service.yaml
+++ b/charts/openbao/templates/ui-service.yaml
@@ -23,13 +23,11 @@ metadata:
     {{- end -}}
   {{- template "openbao.ui.annotations" . }}
 spec:
-  {{- if (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) }}
   {{- if .Values.ui.serviceIPFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.ui.serviceIPFamilyPolicy }}
   {{- end }}
   {{- if .Values.ui.serviceIPFamilies }}
   ipFamilies: {{ .Values.ui.serviceIPFamilies | toYaml | nindent 2 }}
-  {{- end }}
   {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "openbao.name" . }}

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -837,7 +837,6 @@ server:
     # The IP family and IP families options are to set the behaviour in a dual-stack environment.
     # Omitting these values will let the service fall back to whatever the CNI dictates the defaults
     # should be.
-    # These are only supported for kubernetes versions >=1.23.0
     #
     # Configures the service's supported IP family policy, can be either:
     #     SingleStack: Single-stack service. The control plane allocates a cluster IP for the Service, using the first configured service cluster IP range.
@@ -1183,7 +1182,6 @@ ui:
   # The IP family and IP families options are to set the behaviour in a dual-stack environment.
   # Omitting these values will let the service fall back to whatever the CNI dictates the defaults
   # should be.
-  # These are only supported for kubernetes versions >=1.23.0
   #
   # Configures the service's supported IP family, can be either:
   #     SingleStack: Single-stack service. The control plane allocates a cluster IP for the Service, using the first configured service cluster IP range.


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

Removes obsolete Kubernetes compatibility checks that are no longer needed now that the chart requires Kubernetes 1.30 or later.

This removes:

- deprecated v1beta1 API fallbacks
  - [`admissionregistration.k8s.io/v1beta1`](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#webhook-resources-v122): no longer served as of K8s v1.22
  - [`rbac.authorization.k8s.io/v1beta1`](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122): no longer served as of K8s v1.22
- Kubernetes < 1.23 version checks
  - [ipFamilyPolicy and ipFamilies](https://kubernetes.io/blog/2021/12/08/dual-stack-networking-ga/): dual-stack networking became GA in Kubernetes v1.23
  - [persistentVolumeClaimRetentionPolicy](https://kubernetes.io/blog/2023/05/04/kubernetes-1-27-statefulset-pvc-auto-deletion-beta/): available since Kubernetes v1.23 and beta by v1.27
- unused Kubernetes version variables

It also updates related comments in `values.yaml`.

# Rationale

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

`Chart.yaml` requires Kubernetes >= 1.30.0-0, so these compatibility branches only target unsupported Kubernetes versions.
https://github.com/openbao/openbao-helm/blob/98aa674e9697161f06a1515ea9074756ce5b8bc3/charts/openbao/Chart.yaml#L8

The rendered manifests for supported Kubernetes versions are unchanged.

---
No related issue. I'm happy to create one if prior discussion is preferred.

[PodSecurityPolicy support is no longer served as of Kubernetes v1.25](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#psp-v125), but removing it would be a breaking change. I have intentionally left it out of this PR so it can be handled separately.

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
  (no change generated)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
