### PR TITLE
fix(snapshot-agent): fix namespace and token path configuration 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- fix(snapshot-agent): fix namespace and token path configuration
+
 ## 0.29.0
 
 - fix(httpRoute): template timeouts in rule

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -328,7 +328,7 @@ Kubernetes: `>= 1.30.0-0`
 | serverTelemetry.serviceMonitor.selectors | object | `{}` |  |
 | serverTelemetry.serviceMonitor.tlsConfig | object | `{}` |  |
 | snapshotAgent.annotations | object | `{}` |  |
-| snapshotAgent.config.baoAuthNamepace | string | `""` |  |
+| snapshotAgent.config.baoAuthNamespace | string | `""` |  |
 | snapshotAgent.config.baoAuthPath | string | `"kubernetes"` |  |
 | snapshotAgent.config.baoNamespace | string | `""` |  |
 | snapshotAgent.config.baoRole | string | `"snapshot"` |  |

--- a/charts/openbao/templates/_helpers.tpl
+++ b/charts/openbao/templates/_helpers.tpl
@@ -1217,7 +1217,7 @@ config file from values
 {{- end -}}
 
 {{/*
-Create the name of the service account to use for the snasphot-agent
+Create the name of the service account to use for the snapshot-agent
 */}}
 {{- define "openbao.snapshotAgent.serviceAccount.name" -}}
 {{- if .Values.snapshotAgent.serviceAccount.create -}}

--- a/charts/openbao/templates/snapshotagent-configmap.yaml
+++ b/charts/openbao/templates/snapshotagent-configmap.yaml
@@ -23,13 +23,13 @@ data:
   {{- if .Values.snapshotAgent.config.baoNamespace }}
   BAO_NAMESPACE: {{ .Values.snapshotAgent.config.baoNamespace }}
   {{- end }}
-  {{- if .Values.snapshotAgent.config.baoAuthPath }}
+  {{- if .Values.snapshotAgent.config.baoAuthNamespace }}
   BAO_AUTH_NAMESPACE: {{ .Values.snapshotAgent.config.baoAuthNamespace }}
   {{- end }}
   {{- if .Values.snapshotAgent.config.baoSecretPath }}
   BAO_SECRET_PATH: {{ .Values.snapshotAgent.config.baoSecretPath }}
   {{- end }}
-  {{- if .Values.snapshotAgent.config.baoTokenPath }}
+  {{- if .Values.snapshotAgent.config.tokenPath }}
   TOKEN_PATH: {{ .Values.snapshotAgent.config.tokenPath }}
   {{- end }}
   BAO_ROLE: {{ .Values.snapshotAgent.config.baoRole }}

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1581,15 +1581,17 @@ snapshotAgent:
     s3Uri: "s3://openbao-snapshots"
     s3ExpireDays: "14"
     s3cmdExtraFlag: "-v"
-    baoAuthPath: "kubernetes"
-    baoRole: "snapshot"
     # The path of the Kubernetes authentication backend in OpenBao (e.g. `kubernetes`)
+    baoAuthPath: "kubernetes"
+    # OpenBao role to use to create the snapshot
+    baoRole: "snapshot"
+    # OpenBao namespace to be used. Leave empty for non-namespace installations.
     baoNamespace: ""
-    #  Namespace for bao authentication. If authentication namespace needs to be different to `BAO_NAMESPACE`.
-    baoAuthNamepace: ""
+    # Namespace for bao authentication. If authentication namespace needs to be different to `BAO_NAMESPACE`.
+    baoAuthNamespace: ""
     # Secret path to retrieve S3 credentials from. Expects the secret to have two fields: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
     baoSecretPath: ""
-    #  The path of the Kubernetes service account token. If unset defaults to `/var/run/secrets/kubernetes.io/serviceaccount/token`.
+    # The path of the Kubernetes service account token. If unset defaults to `/var/run/secrets/kubernetes.io/serviceaccount/token`.
     tokenPath: ""
 
   # configuration of the CronJobs resources

--- a/test/unit/snapshotagent.bats
+++ b/test/unit/snapshotagent.bats
@@ -202,6 +202,18 @@ load _helpers
   [ "${actual}" = "-q" ]
 }
 
+@test "snapshot/configmap: configuration: baoNamespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+    --show-only templates/snapshotagent-configmap.yaml \
+    --set 'snapshotAgent.enabled=true' \
+    --set 'snapshotAgent.config.baoNamespace=bar' \
+    --namespace foo \
+    . | tee /dev/stderr |
+    yq -r '.data.BAO_NAMESPACE' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "snapshot/configmap: configuration: baoAuthPath" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -212,6 +224,29 @@ load _helpers
     . | tee /dev/stderr |
     yq -r '.data.BAO_AUTH_PATH' | tee /dev/stderr)
   [ "${actual}" = "jwt" ]
+}
+
+@test "snapshot/configmap: configuration: baoAuthNamespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+    --show-only templates/snapshotagent-configmap.yaml \
+    --set 'snapshotAgent.enabled=true' \
+    --set 'snapshotAgent.config.baoAuthNamespace=bar' \
+    --namespace foo \
+    . | tee /dev/stderr |
+    yq -r '.data.BAO_AUTH_NAMESPACE' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "snapshot/configmap: configuration: baoAuthNamespace omitted when empty" {
+  cd `chart_dir`
+  local actual=$(helm template \
+    --show-only templates/snapshotagent-configmap.yaml \
+    --set 'snapshotAgent.enabled=true' \
+    --namespace foo \
+    . | tee /dev/stderr |
+    yq -r '.data | has("BAO_AUTH_NAMESPACE")' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
 }
 
 @test "snapshot/configmap: configuration: baoRole" {
@@ -226,6 +261,18 @@ load _helpers
       yq -r '.data.BAO_ROLE' | tee /dev/stderr
   )
   [ "${actual}" = "backup" ]
+}
+
+@test "snapshot/configmap: configuration: tokenPath" {
+  cd `chart_dir`
+  local actual=$(helm template \
+    --show-only templates/snapshotagent-configmap.yaml \
+    --set 'snapshotAgent.enabled=true' \
+    --set 'snapshotAgent.config.tokenPath=/custom/token' \
+    --namespace foo \
+    . | tee /dev/stderr |
+    yq -r '.data.TOKEN_PATH' | tee /dev/stderr)
+  [ "${actual}" = "/custom/token" ]
 }
 
 @test "snapshot/configmap: configuration: baoAddr" {


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

<!-- Describe the changes your PR introduces here. -->

Fixes several inconsistencies in the Snapshot Agent configuration.

- fixes the `baoAuthNamepace` typo and renames it to `baoAuthNamespace`
- fixes the `TOKEN_PATH` condition to reference `snapshotAgent.config.tokenPath`
- renders `BAO_AUTH_NAMESPACE` only when `baoAuthNamespace` is configured
- fixes related comments and typos
- adds regression tests for `baoAuthNamespace`, `baoNamespace`, and `tokenPath`
- updates the generated `README` using `helm-docs`

# Rationale

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

Some Snapshot Agent configuration values were not rendered as intended due to mismatched value names and conditions.

In particular,

- `tokenPath` could not be rendered because the template checked the non-existent `baoTokenPath` value
- `baoAuthNamespace` was misspelled as `baoAuthNamepace` in `values.yaml`
- `BAO_AUTH_NAMESPACE` was rendered based on `baoAuthPath` instead of `baoAuthNamespace`. Combined with the misspelled `baoAuthNamepace` value, this caused the default manifest to render `BAO_AUTH_NAMESPACE` with no value

For example, before this change, rendering the snapshot-agent ConfigMap with the default configuration generated this:

```console
kangetsu@ubuntu24:~/oss/openbao-helm$ helm template openbao ./charts/openbao \
  --show-only templates/snapshotagent-configmap.yaml \
  --set snapshotAgent.enabled=true | yq .data
{
  "S3_HOST": "s3.eu-east-1.amazonaws.com",
  "S3_BUCKET": "openbao-snapshots",
  "S3CMD_EXTRA_FLAG": "-v",
  "S3_URI": "s3://openbao-snapshots",
  "S3_EXPIRE_DAYS": "14",
  "BAO_AUTH_PATH": "kubernetes",
  "BAO_AUTH_NAMESPACE": null,
  "BAO_ROLE": "snapshot",
  "BAO_ADDR": "http://openbao.default.svc:8200"
}
kangetsu@ubuntu24:~/oss/openbao-helm$
```

After this change, the same command generates this:

```console
kangetsu@ubuntu24:~/oss/openbao-helm$ helm template openbao ./charts/openbao \
  --show-only templates/snapshotagent-configmap.yaml \
  --set snapshotAgent.enabled=true | yq .data
{
  "S3_HOST": "s3.eu-east-1.amazonaws.com",
  "S3_BUCKET": "openbao-snapshots",
  "S3CMD_EXTRA_FLAG": "-v",
  "S3_URI": "s3://openbao-snapshots",
  "S3_EXPIRE_DAYS": "14",
  "BAO_AUTH_PATH": "kubernetes",
  "BAO_ROLE": "snapshot",
  "BAO_ADDR": "http://openbao.default.svc:8200"
}
kangetsu@ubuntu24:~/oss/openbao-helm$ 
```

These changes align the Helm values with the generated ConfigMap and add tests to prevent regressions.

## Reference

The Snapshot Agent environment variables and their semantics are documented here:

https://github.com/openbao/openbao-snapshot-agent/blob/0157e5ed21d990ebf73a8169da6e243da295cde7/kubernetes/README.md

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
