### PR TITLE
feat: support matchConditions for agent-injector webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- feat: Support matchConditions for agent-injector webhook
+
 ## 0.29.1
 
 - fix(snapshot-agent): fix namespace and token path configuration

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -150,6 +150,7 @@ Kubernetes: `>= 1.30.0-0`
 | injector.topologySpreadConstraints | list | `[]` |  |
 | injector.webhook.annotations | object | `{}` |  |
 | injector.webhook.failurePolicy | string | `"Ignore"` |  |
+| injector.webhook.matchConditions | list | `[]` |  |
 | injector.webhook.matchPolicy | string | `"Exact"` |  |
 | injector.webhook.namespaceSelector | object | `{}` |  |
 | injector.webhook.objectSelector | string | `"matchExpressions:\n- key: app.kubernetes.io/name\n  operator: NotIn\n  values:\n  - {{ template \"openbao.name\" . }}-agent-injector\n"` |  |

--- a/charts/openbao/templates/injector-mutating-webhook.yaml
+++ b/charts/openbao/templates/injector-mutating-webhook.yaml
@@ -37,4 +37,8 @@ webhooks:
 {{ toYaml (((.Values.injector.webhook)).namespaceSelector | default .Values.injector.namespaceSelector) | indent 6}}
 {{ end }}
 {{- template "injector.objectSelector" . -}}
+{{- if (.Values.injector.webhook).matchConditions }}
+    matchConditions:
+{{ toYaml .Values.injector.webhook.matchConditions | indent 6}}
+{{ end }}
 {{ end }}

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -210,6 +210,16 @@ injector:
         values:
         - {{ template "openbao.name" . }}-agent-injector
 
+    # matchConditions is a list of CEL expressions for restricting the webhook to only
+    # specific requests.
+    # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchconditions
+    # for more details.
+    # Example:
+    # matchConditions:
+    #   - name: has-agent-inject-annotation
+    #     expression: 'has(object.metadata.annotations) && "openbao.org/agent-inject" in object.metadata.annotations'
+    matchConditions: []
+
     # Extra annotations to attach to the webhook
     annotations: {}
 

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -332,3 +332,36 @@ load _helpers
 
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# matchConditions
+
+@test "injector/MutatingWebhookConfiguration: webhook.matchConditions empty by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.webhooks[0].matchConditions' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: can set webhook.matchConditions" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook.matchConditions[0].name=has-annotation' \
+      --set 'injector.webhook.matchConditions[0].expression=has(object.metadata.annotations)' \
+      . | tee /dev/stderr |
+      yq -r '.webhooks[0].matchConditions[] | select(.name == "has-annotation")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "has-annotation" ]
+
+  local actual=$(echo $object |
+      yq -r '.expression' | tee /dev/stderr)
+  [ "${actual}" = "has(object.metadata.annotations)" ]
+}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->

# Description

<!-- Describe the changes your PR introduces here. -->

Allows setting `matchConditions` on the agent-injector MutatingWebhookConfiguration.
https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchconditions

# Rationale

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

    Once it is approved we will squash your changes onto the default branch
    and our trusty bot account will release them to the repository.
-->
