### PR TITLE
feat(snapshotagent): allow configuring `BAO_TLS_SERVER_NAME`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- feat(snapshotagent): allow configuring `BAO_TLS_SERVER_NAME`
 - fix: ConcurrencyPolicy for snapshot-agent's CronJob
 - fix(chart): remove obsolete PodSecurityPolicy support
 - chore(openshift): use UBI image for csi agent

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -327,11 +327,13 @@ Kubernetes: `>= 1.30.0-0`
 | serverTelemetry.serviceMonitor.selectors | object | `{}` |  |
 | serverTelemetry.serviceMonitor.tlsConfig | object | `{}` |  |
 | snapshotAgent.annotations | object | `{}` |  |
+| snapshotAgent.concurrencyPolicy | string | `"Forbid"` |  |
 | snapshotAgent.config.baoAuthNamespace | string | `""` |  |
 | snapshotAgent.config.baoAuthPath | string | `"kubernetes"` |  |
 | snapshotAgent.config.baoNamespace | string | `""` |  |
 | snapshotAgent.config.baoRole | string | `"snapshot"` |  |
 | snapshotAgent.config.baoSecretPath | string | `""` |  |
+| snapshotAgent.config.baoTlsServerName | string | `""` |  |
 | snapshotAgent.config.s3Bucket | string | `"openbao-snapshots"` |  |
 | snapshotAgent.config.s3ExpireDays | string | `"14"` |  |
 | snapshotAgent.config.s3Host | string | `"s3.eu-east-1.amazonaws.com"` |  |

--- a/charts/openbao/templates/snapshotagent-configmap.yaml
+++ b/charts/openbao/templates/snapshotagent-configmap.yaml
@@ -40,4 +40,7 @@ data:
   {{- else }}
   BAO_ADDR: {{ include "openbao.scheme" . }}://{{ template "openbao.fullname" . }}.{{ include "openbao.namespace" . }}.svc:{{ .Values.server.service.port }}
   {{- end }}
+  {{- if .Values.snapshotAgent.config.baoTlsServerName }}
+  BAO_TLS_SERVER_NAME: {{ .Values.snapshotAgent.config.baoTlsServerName }}
+  {{- end }}
 {{ end }}

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1582,6 +1582,8 @@ snapshotAgent:
     s3Uri: "s3://openbao-snapshots"
     s3ExpireDays: "14"
     s3cmdExtraFlag: "-v"
+    # The TLS server name to use as the SNI host.
+    baoTlsServerName: ""
     # The path of the Kubernetes authentication backend in OpenBao (e.g. `kubernetes`)
     baoAuthPath: "kubernetes"
     # OpenBao role to use to create the snapshot

--- a/test/unit/snapshotagent.bats
+++ b/test/unit/snapshotagent.bats
@@ -224,6 +224,19 @@ load _helpers
   [ "${actual}" = "-q" ]
 }
 
+@test "snapshot/configmap: configuration: baoTlsServerName" {
+  cd `chart_dir`
+  local actual=$(helm template \
+    --show-only templates/snapshotagent-configmap.yaml \
+    --set 'snapshotAgent.enabled=true' \
+    --set 'snapshotAgent.config.baoTlsServerName=foo' \
+    --namespace foo \
+    . | tee /dev/stderr |
+    yq -r '.data.BAO_TLS_SERVER_NAME' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+}
+
+
 @test "snapshot/configmap: configuration: baoNamespace" {
   cd `chart_dir`
   local actual=$(helm template \


### PR DESCRIPTION
# Description

Related issue #220 

Introduce a new key that expose configuration of `BAO_TLS_SERVER_NAME` for the snapshot agent configuration.

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.