### PR TITLE
feat(snapshotAgent): allow setting nodeSelector and affinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- feat: Allow setting nodeSelector and affinity for snapshot-agent cronjob pod
+
 ## 0.29.3
 
 - fix: ConcurrencyPolicy for snapshot-agent's CronJob

--- a/charts/openbao/README.md
+++ b/charts/openbao/README.md
@@ -326,6 +326,7 @@ Kubernetes: `>= 1.30.0-0`
 | serverTelemetry.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
 | serverTelemetry.serviceMonitor.selectors | object | `{}` |  |
 | serverTelemetry.serviceMonitor.tlsConfig | object | `{}` |  |
+| snapshotAgent.affinity | object | `{}` |  |
 | snapshotAgent.annotations | object | `{}` |  |
 | snapshotAgent.concurrencyPolicy | string | `"Forbid"` |  |
 | snapshotAgent.config.baoAuthNamespace | string | `""` |  |
@@ -346,6 +347,7 @@ Kubernetes: `>= 1.30.0-0`
 | snapshotAgent.extraVolumes | list | `[]` | List of extraVolumes made available to the snapshot cronjob container. |
 | snapshotAgent.image.repository | string | `"ghcr.io/openbao/openbao-snapshot-agent"` |  |
 | snapshotAgent.image.tag | string | `"0.4.1"` |  |
+| snapshotAgent.nodeSelector | object | `{}` |  |
 | snapshotAgent.resources | object | `{}` |  |
 | snapshotAgent.restartPolicy | string | `"OnFailure"` |  |
 | snapshotAgent.s3CredentialsSecret | string | `""` | Existing Kubernetes secret with S3 Credentials. Must contain keys called AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. If not provided, you must provide `snapshotAgent.extraSecretEnvironmentVars` |

--- a/charts/openbao/templates/_helpers.tpl
+++ b/charts/openbao/templates/_helpers.tpl
@@ -1304,3 +1304,33 @@ tolerations for the snapshotAgent cronjob pod
           {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+nodeSelector for the snapshotAgent cronjob pod
+*/}}
+{{- define "snapshotAgent.nodeselector" -}}
+  {{- if .Values.snapshotAgent.nodeSelector }}
+          nodeSelector:
+          {{- $tp := typeOf .Values.snapshotAgent.nodeSelector }}
+          {{- if eq $tp "string" }}
+            {{ tpl .Values.snapshotAgent.nodeSelector . | nindent 12 | trim }}
+          {{- else }}
+            {{- toYaml .Values.snapshotAgent.nodeSelector | nindent 12 }}
+          {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+affinity for the snapshotAgent cronjob pod
+*/}}
+{{- define "snapshotAgent.affinity" -}}
+  {{- if .Values.snapshotAgent.affinity }}
+          affinity:
+          {{- $tp := typeOf .Values.snapshotAgent.affinity }}
+          {{- if eq $tp "string" }}
+            {{ tpl .Values.snapshotAgent.affinity . | nindent 12 | trim }}
+          {{- else }}
+            {{- toYaml .Values.snapshotAgent.affinity | nindent 12 }}
+          {{- end }}
+  {{- end }}
+{{- end -}}

--- a/charts/openbao/templates/snapshotagent-cronjob.yaml
+++ b/charts/openbao/templates/snapshotagent-cronjob.yaml
@@ -31,6 +31,8 @@ spec:
           serviceAccountName: {{  template "openbao.snapshotAgent.serviceAccount.name" . }}
           {{ template "snapshotAgent.securityContext.pod" .}}
           {{ template "snapshotAgent.tolerations" . }}
+          {{ template "snapshotAgent.nodeselector" . }}
+          {{ template "snapshotAgent.affinity" . }}
           containers:
           - name: bao-snapshot
             envFrom:

--- a/charts/openbao/values.yaml
+++ b/charts/openbao/values.yaml
@@ -1630,3 +1630,14 @@ snapshotAgent:
   # This should be either a multi-line string or YAML matching the Toleration array
   # in a PodSpec.
   tolerations: []
+
+  # nodeSelector labels for snapshot-agent cronjob pod assignment, formatted as a multi-line string or YAML map.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  # nodeSelector:
+  #   beta.kubernetes.io/arch: amd64
+  nodeSelector: {}
+
+  # Affinity Settings for snapshot-agent cronjob pod
+  # This should be either a multi-line string or YAML matching the PodSpec's affinity field.
+  affinity: {}

--- a/test/unit/snapshotagent.bats
+++ b/test/unit/snapshotagent.bats
@@ -510,3 +510,73 @@ load _helpers
       yq '.spec.jobTemplate.spec.template.spec.tolerations == [{"foo": "bar"}, {"baz": "qux"}]' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# nodeSelector
+
+@test "snapshot/cronjob: nodeSelector not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/snapshotagent-cronjob.yaml \
+      --set 'snapshotAgent.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec | .nodeSelector? == null' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/cronjob: nodeSelector can be set as string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/snapshotagent-cronjob.yaml \
+      --set 'snapshotAgent.enabled=true' \
+      --set 'snapshotAgent.nodeSelector=foobar' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec.nodeSelector == "foobar"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/cronjob: nodeSelector can be set as YAML" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/snapshotagent-cronjob.yaml \
+      --set 'snapshotAgent.enabled=true' \
+      --set "snapshotAgent.nodeSelector.foo=bar,snapshotAgent.nodeSelector.baz=qux" \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec.nodeSelector == {"foo": "bar", "baz": "qux"}' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# affinity
+
+@test "snapshot/cronjob: affinity not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/snapshotagent-cronjob.yaml \
+      --set 'snapshotAgent.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec | .affinity? == null' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/cronjob: affinity can be set as string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/snapshotagent-cronjob.yaml \
+      --set 'snapshotAgent.enabled=true' \
+      --set 'snapshotAgent.affinity=foobar' \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec.affinity == "foobar"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "snapshot/cronjob: affinity can be set as YAML" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/snapshotagent-cronjob.yaml \
+      --set 'snapshotAgent.enabled=true' \
+      --set "snapshotAgent.affinity.podAntiAffinity=foobar" \
+      . | tee /dev/stderr |
+      yq '.spec.jobTemplate.spec.template.spec.affinity.podAntiAffinity == "foobar"' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}


### PR DESCRIPTION
# Description

Adds `snapshotAgent.nodeSelector` and `snapshotAgent.affinity`, so the snapshot cronjob pod can be placed like the server, injector and CSI provider pods already can.

# Rationale

# Checklist

- [x] This PR contains a description of the changes I'm making
- [x] I read the `CONTRIBUTING.md` guide
- [x] I update the changelog in `CHANGELOG.md`
- [x] I updated applicable `README.md` files using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] By contributing this change, I certify I have signed-off on the
      [DCO ownership](https://developercertificate.org/) statement
      and this change did not use post-BUSL-licensed code from HashiCorp.
      Existing MPL-licensed code is still allowed, subject to attribution.
      Code authored by yourself and submitted to HashiCorp for inclusion is
      also allowed.
